### PR TITLE
Change main.storyboard module name

### DIFF
--- a/Bluetooth/Supporting Files/Main.storyboard
+++ b/Bluetooth/Supporting Files/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kEX-h7-8hn">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kEX-h7-8hn">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -29,13 +29,13 @@
         <!--View Controller-->
         <scene sceneID="JDY-UX-VJl">
             <objects>
-                <viewController id="KMh-Kw-yG4" customClass="ViewController" customModule="Bluetooth_Demo" sceneMemberID="viewController">
+                <viewController id="KMh-Kw-yG4" customClass="ViewController" customModule="BlueSwiftSample" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="frN-J3-f3d">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="hQT-YX-G5g">
-                                <rect key="frame" x="134" y="278.5" width="106" height="110"/>
+                                <rect key="frame" x="134.5" y="278.5" width="106" height="110"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1W5-pn-g4j">
                                         <rect key="frame" x="0.0" y="0.0" width="106" height="30"/>
@@ -70,7 +70,7 @@
         <!--Advertisement View Controller-->
         <scene sceneID="UYj-xF-5gF">
             <objects>
-                <viewController id="hEK-kS-TRu" customClass="AdvertisementViewController" customModule="Bluetooth_Demo" sceneMemberID="viewController">
+                <viewController id="hEK-kS-TRu" customClass="AdvertisementViewController" customModule="BlueSwiftSample" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="frJ-vL-qJg">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -113,7 +113,7 @@
                                 </subviews>
                             </stackView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="dSo-c5-C1d">
-                                <rect key="frame" x="37" y="414" width="300" height="200"/>
+                                <rect key="frame" x="37.5" y="414" width="300" height="200"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="200" id="MiW-3k-0Fb"/>
@@ -155,13 +155,13 @@
         <!--Connection View Controller-->
         <scene sceneID="9QC-iW-zk4">
             <objects>
-                <viewController id="0eC-V9-5DZ" customClass="ConnectionViewController" customModule="Bluetooth_Demo" sceneMemberID="viewController">
+                <viewController id="0eC-V9-5DZ" customClass="ConnectionViewController" customModule="BlueSwiftSample" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="HT6-Lc-Q64">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="tD4-dv-mGE">
-                                <rect key="frame" x="37.5" y="153.5" width="300" height="361"/>
+                                <rect key="frame" x="37.5" y="153" width="300" height="361"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PxK-tF-iWY">
                                         <rect key="frame" x="0.0" y="0.0" width="300" height="30"/>


### PR DESCRIPTION
### Title
<!-- In a few words, please provide a short title of proposed change. -->
This PR fixes wrong module name specified in main.storyboard from `Bluetooth_Demo` to `BlueSwiftSample`. In current state demo app crashes what is described in #16 

### Motivation
<!-- Please describe why do you want to implement this change. -->
Demo should work 😇 

### Task Description
<!-- What should and what actually happens. -->
`Bluetooth_Demo` is invalid module name. I suspect that sample target has had this name some time ago but it has changed probably during a refactor. PR replaces this value to `BlueSwiftSample` which is valid module name.

To prevent such issues in the feature I've also selected `Inherit Module From Target` what is visible in `Main.storyboard` file as `customModuleProvider="target"`.