### PR TITLE
Added RSSI, name and setting peripheral a bit earlier

### DIFF
--- a/Framework/Source Files/Connection/BluetoothConnection.swift
+++ b/Framework/Source Files/Connection/BluetoothConnection.swift
@@ -23,13 +23,23 @@ public final class BluetoothConnection: NSObject {
     /// Maximum amount of devices capable of connecting to a iOS device.
     private let deviceConnectionLimit = 8
     
+    /// A advertisement validation handler. Will be called upon every peripheral discovery. Return value from this closure
+    /// will indicate if manager should or shouldn't start connection with the passed peripheral according to it's identifier
+    /// and advertising packet.
+    @available(*, deprecated, message: "This closure will be removed in future version. Please use `peripheralValidationHandler`.")
+    public var advertisementValidationHandler: ((Peripheral<Connectable>, String, [String: Any]) -> (Bool))? {
+        didSet {
+            connectionService.advertisementValidationHandler = advertisementValidationHandler
+        }
+    }
+
     /// A advertisement validation handler. Will be called upon every peripheral discovery. Contains matched peripheral,
     /// discovered peripheral from CoreBluetooth, advertisement data and RSSI value. Return value from this closure
     /// will indicate if manager should or shouldn't start connection with the passed peripheral according to it's identifier
     /// and advertising packet.
-    public var advertisementValidationHandler: ((Peripheral<Connectable>, CBPeripheral, [String: Any], NSNumber) -> (Bool))? {
+    public var peripheralValidationHandler: ((Peripheral<Connectable>, CBPeripheral, [String: Any], NSNumber) -> (Bool))? {
         didSet {
-            connectionService.advertisementValidationHandler = advertisementValidationHandler
+            connectionService.peripheralValidationHandler = peripheralValidationHandler
         }
     }
     

--- a/Framework/Source Files/Connection/BluetoothConnection.swift
+++ b/Framework/Source Files/Connection/BluetoothConnection.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import CoreBluetooth
 
 /// Public facing interface granting methods to connect and disconnect devices.
 public final class BluetoothConnection: NSObject {
@@ -22,10 +23,11 @@ public final class BluetoothConnection: NSObject {
     /// Maximum amount of devices capable of connecting to a iOS device.
     private let deviceConnectionLimit = 8
     
-    /// A advertisement validation handler. Will be called upon every peripheral discovery. Return value from this closure
+    /// A advertisement validation handler. Will be called upon every peripheral discovery. Contains matched peripheral,
+    /// discovered peripheral from CoreBluetooth, advertisement data and RSSI value. Return value from this closure
     /// will indicate if manager should or shouldn't start connection with the passed peripheral according to it's identifier
     /// and advertising packet.
-    public var advertisementValidationHandler: ((Peripheral<Connectable>, String, [String: Any]) -> (Bool))? {
+    public var advertisementValidationHandler: ((Peripheral<Connectable>, CBPeripheral, [String: Any], NSNumber) -> (Bool))? {
         didSet {
             connectionService.advertisementValidationHandler = advertisementValidationHandler
         }

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -10,7 +10,10 @@ import CoreBluetooth
 internal final class ConnectionService: NSObject {
     
     /// Closure used to check given peripheral against advertisement packet of discovered peripheral.
-    internal var advertisementValidationHandler: ((Peripheral<Connectable>, CBPeripheral, [String: Any], NSNumber) -> (Bool))? = { _,_,_,_ in return true }
+    internal var advertisementValidationHandler: ((Peripheral<Connectable>, String, [String: Any]) -> (Bool))? = { _,_,_ in return true }
+
+    /// Closure used to check given peripheral against advertisement packet of discovered peripheral.
+    internal var peripheralValidationHandler: ((Peripheral<Connectable>, CBPeripheral, [String: Any], NSNumber) -> (Bool))? = { _,_,_,_ in return true }
 
     /// Closure used to manage connection success or failure.
     internal var connectionHandler: ((Peripheral<Connectable>, ConnectionError?) -> ())?
@@ -115,7 +118,7 @@ extension ConnectionService: CBCentralManagerDelegate {
     public func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String : Any], rssi RSSI: NSNumber) {
         let devices = peripherals.filter({ $0.configuration.matches(advertisement: advertisementData)})
 
-        guard let handler = advertisementValidationHandler,
+        guard let handler = peripheralValidationHandler,
             let matchingPeripheral = devices.filter({ $0.peripheral == nil }).first,
             handler(matchingPeripheral, peripheral, advertisementData, RSSI),
             connectingPeripheral == nil

--- a/Framework/Source Files/Model/Peripheral/ConnectablePeripheral.swift
+++ b/Framework/Source Files/Model/Peripheral/ConnectablePeripheral.swift
@@ -70,6 +70,14 @@ public extension Peripheral where Type == Connectable {
             handler?(nil, error as? TransmissionError)
         }
     }
+
+    /// Method used to perform read RSSI request from peripheral.
+    /// 
+    /// - Parameter handler: completion handler returning RSSI value retrieved from peripheral.
+    func readRSSI(_ handler: ((NSNumber?, TransmissionError?) -> ())?) {
+        rssiHandler = handler
+        peripheral?.readRSSI()
+    }
     
     /// Performs a general validation if write or read requests can be performed on specified characteristic.
     private func validateForTransmission(_ characteristic: Characteristic, action: TransmissionAction) throws -> CBCharacteristic {

--- a/Framework/Source Files/Model/Peripheral/ConnectablePeripheral.swift
+++ b/Framework/Source Files/Model/Peripheral/ConnectablePeripheral.swift
@@ -72,9 +72,12 @@ public extension Peripheral where Type == Connectable {
     }
 
     /// Method used to perform read RSSI request from peripheral.
-    /// 
+    ///
     /// - Parameter handler: completion handler returning RSSI value retrieved from peripheral.
-    func readRSSI(_ handler: ((NSNumber?, TransmissionError?) -> ())?) {
+    func readRSSI(_ handler: ((NSNumber?, TransmissionError?) -> ())?) throws {
+        guard isConnected else {
+            throw TransmissionError.deviceNotConnected
+        }
         rssiHandler = handler
         peripheral?.readRSSI()
     }

--- a/Framework/Source Files/Model/Peripheral/ConnectablePeripheral.swift
+++ b/Framework/Source Files/Model/Peripheral/ConnectablePeripheral.swift
@@ -74,9 +74,10 @@ public extension Peripheral where Type == Connectable {
     /// Method used to perform read RSSI request from peripheral.
     ///
     /// - Parameter handler: completion handler returning RSSI value retrieved from peripheral.
-    func readRSSI(_ handler: ((NSNumber?, TransmissionError?) -> ())?) throws {
+    func readRSSI(_ handler: ((NSNumber?, TransmissionError?) -> ())?) {
         guard isConnected else {
-            throw TransmissionError.deviceNotConnected
+            handler?(nil, .deviceNotConnected)
+            return
         }
         rssiHandler = handler
         peripheral?.readRSSI()

--- a/Framework/Source Files/Model/Peripheral/Peripheral.swift
+++ b/Framework/Source Files/Model/Peripheral/Peripheral.swift
@@ -42,6 +42,14 @@ public final class Peripheral<Type: PeripheralType>: NSObject, CBPeripheralDeleg
     /// A device parameter. Should be cached locally in order to pass for every connection after the first one.
     /// If passed, every connection should happen much quicker.
     public var deviceIdentifier: String?
+
+    /// Name of the peripheral returned from Apple native peripheral class.
+    public var name: String? {
+        return peripheral?.name
+    }
+
+    /// Last received signal strength indicator of the peripheral, in decibels.
+    public var rssi: NSNumber?
     
     internal var advertisementData: [AdvertisementData]?
     
@@ -57,6 +65,9 @@ public final class Peripheral<Type: PeripheralType>: NSObject, CBPeripheralDeleg
     
     /// Private variable for storing reference to read completion callback.
     internal var readHandler: ((Data?, TransmissionError?) -> ())?
+
+    /// Private variable for storing reference to read rssi completion callback.
+    internal var rssiHandler: ((NSNumber?, TransmissionError?) -> ())?
     
     /// Called after reading data from characteristic.
     /// - SeeAlso: `CBPeripheralDelegate`
@@ -89,6 +100,22 @@ public final class Peripheral<Type: PeripheralType>: NSObject, CBPeripheralDeleg
         }
         guard let error = error else {
             handler(characteristic.value, nil)
+            return
+        }
+        handler(nil, .auxiliaryError(error))
+    }
+
+    /// Called after reading RRSI value from peripheral.
+    /// - SeeAlso: `CBPeripheralDelegate`
+    public func peripheral(_ peripheral: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
+        defer {
+            rssiHandler = nil
+        }
+
+        guard let handler = rssiHandler else { return }
+        guard let error = error else {
+            rssi = RSSI
+            handler(RSSI, nil)
             return
         }
         handler(nil, .auxiliaryError(error))


### PR DESCRIPTION
### Title
<!-- In a few words, please provide a short title of proposed change. -->

### Task Description
<!-- What should and what actually happens. -->
In this PR, I've added few things: 
• Last RSSI value stored in peripheral right with functions to read it from device
• Device name returned from native peripheral class
• Changed `advertisementValidationHandler` closure - now providing native peripheral instead of UUID and RSSI value