### PR TITLE
Improvements

### DIFF
--- a/Bluetooth/ConnectionViewController.swift
+++ b/Bluetooth/ConnectionViewController.swift
@@ -71,7 +71,7 @@ class ConnectionViewController: UIViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        try? connection.disconnect(peripheral)
+        connection.disconnect(peripheral)
     }
     
     @IBAction func hideKeyboard() {

--- a/Framework/Source Files/Connection/BluetoothConnection.swift
+++ b/Framework/Source Files/Connection/BluetoothConnection.swift
@@ -75,8 +75,7 @@ public final class BluetoothConnection: NSObject {
     }
 
     /// Function called to stop scanning for devices.
-    /// - Parameter removeUnconnectedDevices: indicates whether unconnected devices should be removed from the list. Default is `true`.
-    public func stopScanning(removeUnconnectedDevices: Bool = true) {
-        connectionService.stopScanning(removeUnconnectedDevices: removeUnconnectedDevices)
+    public func stopScanning() {
+        connectionService.stopScanning()
     }
 }

--- a/Framework/Source Files/Connection/BluetoothConnection.swift
+++ b/Framework/Source Files/Connection/BluetoothConnection.swift
@@ -9,11 +9,6 @@ import CoreBluetooth
 /// Public facing interface granting methods to connect and disconnect devices.
 public final class BluetoothConnection: NSObject {
     
-    /// List of possible disconnection errors.
-    public enum DisconnectionError: Error {
-        case deviceNotConnected
-    }
-    
     /// A singleton instance.
     public static let shared = BluetoothConnection()
     
@@ -65,13 +60,12 @@ public final class BluetoothConnection: NSObject {
     /// Primary method to disconnect a device. If it's not yet connected it'll be removed from connection queue, and connection attempts will stop.
     ///
     /// - Parameter peripheral: a peripheral you wish to disconnect. Should be exactly the same instance that was used for connection.
-    /// - Throws: BluetoothConnection.ConnectionError in case there was a disconnection problem
-    /// - SeeAlso: BluetoothConnection.DisconnectionError
-    public func disconnect(_ peripheral: Peripheral<Connectable>) throws {
-        guard let peripheral = peripheral.peripheral else {
-            throw DisconnectionError.deviceNotConnected
+    public func disconnect(_ peripheral: Peripheral<Connectable>) {
+        guard let cbPeripheral = peripheral.peripheral else {
+            connectionService.remove(peripheral)
+            return
         }
-        connectionService.disconnect(peripheral)
+        connectionService.disconnect(cbPeripheral)
     }
 
     /// Function called to stop scanning for devices.

--- a/Framework/Source Files/Connection/BluetoothConnection.swift
+++ b/Framework/Source Files/Connection/BluetoothConnection.swift
@@ -20,9 +20,6 @@ public final class BluetoothConnection: NSObject {
     /// Connection service implementing native CoreBluetooth stack.
     private lazy var connectionService = ConnectionService()
     
-    /// Maximum amount of devices capable of connecting to a iOS device.
-    private let deviceConnectionLimit = 8
-    
     /// A advertisement validation handler. Will be called upon every peripheral discovery. Return value from this closure
     /// will indicate if manager should or shouldn't start connection with the passed peripheral according to it's identifier
     /// and advertising packet.
@@ -55,7 +52,7 @@ public final class BluetoothConnection: NSObject {
             handler?(.deviceAlreadyConnected)
             return
         }
-        guard connectionService.connectedDevicesAmount <= deviceConnectionLimit else {
+        guard !connectionService.exceededDevicesConnectedLimit else {
             handler?(.deviceConnectionLimitExceed)
             return
         }

--- a/Framework/Source Files/Connection/BluetoothConnection.swift
+++ b/Framework/Source Files/Connection/BluetoothConnection.swift
@@ -76,4 +76,10 @@ public final class BluetoothConnection: NSObject {
         }
         connectionService.disconnect(peripheral)
     }
+
+    /// Function called to stop scanning for devices.
+    /// - Parameter removeUnconnectedDevices: indicates whether unconnected devices should be removed from the list. Default is `true`.
+    public func stopScanning(removeUnconnectedDevices: Bool = true) {
+        connectionService.stopScanning(removeUnconnectedDevices: removeUnconnectedDevices)
+    }
 }

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -69,6 +69,13 @@ extension ConnectionService {
         centralManager.cancelPeripheralConnection(peripheral)
     }
 
+    /// Function called to remove peripheral from queue
+    /// - Parameter peripheral: peripheral to remove.
+    internal func remove(_ peripheral: Peripheral<Connectable>) {
+        guard let index = peripherals.firstIndex(where: { $0 === peripheral }) else { return }
+        peripherals.remove(at: index)
+    }
+
     /// Function called to stop scanning for devices.
     internal func stopScanning() {
         centralManager.stopScan()
@@ -135,8 +142,8 @@ extension ConnectionService: CBCentralManagerDelegate {
             let matchingPeripheral = devices.filter({ $0.peripheral == nil }).first,
             handler(matchingPeripheral, peripheral, advertisementData, RSSI),
             connectingPeripheral == nil
-            else {
-                return
+        else {
+            return
         }
         connectingPeripheral = matchingPeripheral
         connectingPeripheral?.peripheral = peripheral

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -60,6 +60,14 @@ extension ConnectionService {
         }
         centralManager.cancelPeripheralConnection(peripheral)
     }
+
+    /// Function called to stop scanning for devices.
+    /// - Parameter removeUnconnectedDevices: indicates whether unconnected devices should be removed from the list. Default is `true`.
+    internal func stopScanning(removeUnconnectedDevices: Bool = true) {
+        centralManager.stopScan()
+        guard removeUnconnectedDevices else { return }
+        peripherals.removeAll(where: { !$0.isConnected })
+    }
 }
 
 private extension ConnectionService {

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -70,11 +70,8 @@ extension ConnectionService {
     }
 
     /// Function called to stop scanning for devices.
-    /// - Parameter removeUnconnectedDevices: indicates whether unconnected devices should be removed from the list. Default is `true`.
-    internal func stopScanning(removeUnconnectedDevices: Bool = true) {
+    internal func stopScanning() {
         centralManager.stopScan()
-        guard removeUnconnectedDevices else { return }
-        peripherals.removeAll(where: { !$0.isConnected })
     }
 }
 
@@ -102,7 +99,7 @@ private extension ConnectionService {
     /// deviceIdentifier was passed during initialization. If it's correctly retrieved, scanning is unnecessary and peripheral
     /// can be directly connected.
     private func performDeviceAutoReconnection() {
-        let identifiers = peripherals.compactMap { UUID(uuidString: $0.deviceIdentifier ?? "") }
+        let identifiers = peripherals.filter { !$0.isConnected }.compactMap { UUID(uuidString: $0.deviceIdentifier ?? "") }
         guard !identifiers.isEmpty else { return }
         let retrievedPeripherals = centralManager.retrievePeripherals(withIdentifiers: identifiers)
         let matching = peripherals.matchingElementsWith(retrievedPeripherals)

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -145,6 +145,9 @@ extension ConnectionService: CBCentralManagerDelegate {
         connectingPeripheral?.peripheral = peripheral
         connectingPeripheral?.rssi = RSSI
         central.connect(peripheral, options: connectionOptions)
+        if exceededDevicesConnectedLimit {
+            centralManager.stopScan()
+        }
     }
     
     /// Called upon a successfull peripheral connection.

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -18,10 +18,18 @@ internal final class ConnectionService: NSObject {
     /// Closure used to manage connection success or failure.
     internal var connectionHandler: ((Peripheral<Connectable>, ConnectionError?) -> ())?
     
-    /// Returns the amount of devices already scheduled for connection.
+    /// Returns the amount of devices already connected.
     internal var connectedDevicesAmount: Int {
-        return peripherals.count
+        return peripherals.filter { $0.isConnected }.count
     }
+
+    /// Indicates whether connected devices limit has been exceeded.
+    internal var exceededDevicesConnectedLimit: Bool {
+        return connectedDevicesAmount >= deviceConnectionLimit
+    }
+
+    /// Maximum amount of devices capable of connecting to a iOS device.
+    private let deviceConnectionLimit = 8
     
     /// Set of peripherals the manager should connect.
     private var peripherals = [Peripheral<Connectable>]()

--- a/Framework/Source Files/Model/Characteristic.swift
+++ b/Framework/Source Files/Model/Characteristic.swift
@@ -15,6 +15,11 @@ public class Characteristic {
     
     /// A bool indicating if isNotifying value should be set on a characteristic upon discovery.
     public let isObservingValue: Bool
+
+    /// A bool indicating a peripheral can write the characteristic’s value with a response.
+    public var isWriteWithResponse: Bool? {
+        return rawCharacteristic?.properties.contains(.write)
+    }
     
     /// A handler indicating characteristic value update events.
     public var notifyHandler: ((Data?) -> ())?


### PR DESCRIPTION
### Title
<!-- In a few words, please provide a short title of proposed change. -->
I've made few changes due to the implementation BlueSwift in the project.

### Task Description
<!-- What should and what actually happens. -->
In this PR, I've added few changes:
• `deviceConnectionLimit` has been moved to `ConnectionService`.
• `connectedDevicesAmount` in `ConnectionService` returns now connected devices only.
• Added `exceededDevicesConnectedLimit` in `ConnectionService` which returns if connected devices limit has been exceeded.
• Added `stopScanning` function which stops `CBCentralManager`.
• After connecting to the device in `centralManager(_:didDiscover:advertisementData:rssi:)` we're checking now if connected devices limit has exceeded. If yes, then we're stopping scanning.
• Reconnecting only to disconnected devices.
• Changed `BluetoothConnection.disconnect` function to work as documented.
• Added `isWriteWithResponse` to `Characteristic`