### PR TITLE
[FIX] API Misuse warning

### DIFF
--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -99,6 +99,7 @@ private extension ConnectionService {
             return
         }
         scanParameters = Set(params)
+        guard case .poweredOn = centralManager.state else { return }
         centralManager.scanForPeripherals(withServices: Array(scanParameters), options: scanningOptions)
     }
     


### PR DESCRIPTION
### Title
<!-- In a few words, please provide a short title of proposed change. -->
BlueSwift was returning warning in logs about API misuse.

### Task Description
<!-- What should and what actually happens. -->
Function `scanForPeripherals(withServices:options:)` was called before central manager updated its state and because of that compiler was returning warning about API misuse.
```
2019-12-11 13:14:01.866782+0100 BlueSwiftSample[1606:336466] [CoreBluetooth] API MISUSE: <CBCentralManager: 0x2819bdb20> can only accept this command while in the powered on state
```

This function needs to be called only when central manager is in `poweredOn` state. I've added only guard here which will prevent calling this function when state is other than `poweredOn`. State is validated in delegate function, so this will be enough to fix this warning.