### PR TITLE
[FIX] Characteristic properties validation

### DIFF
--- a/Framework/Source Files/Extensions/CBCharacteristic.swift
+++ b/Framework/Source Files/Extensions/CBCharacteristic.swift
@@ -15,6 +15,6 @@ internal extension CBCharacteristic {
     
     /// Validates if given characteristic is writeable.
     func validateForWrite() -> Bool {
-        return properties == .write || properties == .writeWithoutResponse
+        return properties.contains(.write) || properties.contains(.writeWithoutResponse)
     }
 }

--- a/Framework/Source Files/Extensions/CBCharacteristic.swift
+++ b/Framework/Source Files/Extensions/CBCharacteristic.swift
@@ -10,7 +10,7 @@ internal extension CBCharacteristic {
     
     /// Validates if given characteristic is readable.
     func validateForRead() -> Bool {
-        return properties == .read
+        return properties.contains(.read)
     }
     
     /// Validates if given characteristic is writeable.


### PR DESCRIPTION
### Title
<!-- In a few words, please provide a short title of proposed change. -->
Simple fix for characteristic properties validation

### Task Description
<!-- What should and what actually happens. -->
This is simple fix for `properties` check before writing or reading value. CBCharacteristicProperties can contain multiple properties such as `.write` or `.notify` and then checking just to one case will fail. Now I'm checking if properties contains given case.