### PR TITLE
Added disconnection handler to Peripheral

### DIFF
--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -217,7 +217,13 @@ extension ConnectionService: CBPeripheralDelegate {
     /// longer needed we'll just return.
     /// - SeeAlso: CBPeripheralDelegate
     public func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
-        guard let disconnectedPeripheral = peripherals.filter({ $0.peripheral === peripheral }).first?.peripheral else { return }
-        centralManager.connect(disconnectedPeripheral, options: connectionOptions)
+        guard
+            let disconnectedPeripheral = peripherals.filter({ $0.peripheral === peripheral }).first,
+            let nativePeripheral = disconnectedPeripheral.peripheral
+        else {
+            return
+        }
+        disconnectedPeripheral.disconnectionHandler?()
+        centralManager.connect(nativePeripheral, options: connectionOptions)
     }
 }

--- a/Framework/Source Files/Model/Peripheral/Peripheral.swift
+++ b/Framework/Source Files/Model/Peripheral/Peripheral.swift
@@ -50,6 +50,9 @@ public final class Peripheral<Type: PeripheralType>: NSObject, CBPeripheralDeleg
 
     /// Last received signal strength indicator of the peripheral, in decibels.
     public var rssi: NSNumber?
+
+    /// Handler which will be called when device will be disconnected.
+    public var disconnectionHandler: (() -> Void)?
     
     internal var advertisementData: [AdvertisementData]?
     


### PR DESCRIPTION
### Title
<!-- In a few words, please provide a short title of proposed change. -->
Added disconnection handler to Peripheral.

### Task Description
<!-- What should and what actually happens. -->
In this PR I've added disconnection handler to Peripheral which will be called every time upon call from `CBPeripheralDelegate` in `ConnectionService`. Right now we can only check if device is connected (by `isConnected` variable), but there was no way to receive some sort of notification immediately.