### PR TITLE
Validate Bluetooth state when trying to connect peripheral

### DIFF
--- a/Bluetooth.xcodeproj/project.pbxproj
+++ b/Bluetooth.xcodeproj/project.pbxproj
@@ -544,7 +544,7 @@
 				TargetAttributes = {
 					3837BA0A1FFFC2FE00DF300E = {
 						CreatedOnToolsVersion = 9.2;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					3837BA301FFFC4CE00DF300E = {
 						CreatedOnToolsVersion = 9.2;
@@ -701,11 +701,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3A142D24210F0EEE000A6089 /* Sample-Base.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9HJ69C5G9K;
-				PRODUCT_BUNDLE_IDENTIFIER = co.netguru.lib.blueswift.sampleo;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
 		};
@@ -713,11 +708,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3A142D24210F0EEE000A6089 /* Sample-Base.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9HJ69C5G9K;
-				PRODUCT_BUNDLE_IDENTIFIER = co.netguru.lib.blueswift.sampleo;
-				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
 		};
@@ -725,7 +715,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 38FE6BAC2006898100809A06 /* Framework-Base.xcconfig */;
 			buildSettings = {
-				ENABLE_BITCODE = YES;
 			};
 			name = Debug;
 		};
@@ -733,7 +722,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 38FE6BAC2006898100809A06 /* Framework-Base.xcconfig */;
 			buildSettings = {
-				ENABLE_BITCODE = YES;
 			};
 			name = Release;
 		};

--- a/Bluetooth.xcodeproj/project.pbxproj
+++ b/Bluetooth.xcodeproj/project.pbxproj
@@ -544,7 +544,7 @@
 				TargetAttributes = {
 					3837BA0A1FFFC2FE00DF300E = {
 						CreatedOnToolsVersion = 9.2;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 					3837BA301FFFC4CE00DF300E = {
 						CreatedOnToolsVersion = 9.2;
@@ -701,6 +701,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3A142D24210F0EEE000A6089 /* Sample-Base.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9HJ69C5G9K;
+				PRODUCT_BUNDLE_IDENTIFIER = co.netguru.lib.blueswift.sampleo;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
 		};
@@ -708,6 +713,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3A142D24210F0EEE000A6089 /* Sample-Base.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9HJ69C5G9K;
+				PRODUCT_BUNDLE_IDENTIFIER = co.netguru.lib.blueswift.sampleo;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
 		};
@@ -715,6 +725,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 38FE6BAC2006898100809A06 /* Framework-Base.xcconfig */;
 			buildSettings = {
+				ENABLE_BITCODE = YES;
 			};
 			name = Debug;
 		};
@@ -722,6 +733,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 38FE6BAC2006898100809A06 /* Framework-Base.xcconfig */;
 			buildSettings = {
+				ENABLE_BITCODE = YES;
 			};
 			name = Release;
 		};

--- a/Bluetooth/ConnectionViewController.swift
+++ b/Bluetooth/ConnectionViewController.swift
@@ -11,16 +11,26 @@ class ConnectionViewController: UIViewController {
     @IBOutlet weak var notifyLabel: UILabel!
     @IBOutlet weak var readLabel: UILabel!
     @IBOutlet weak var textField: UITextField!
-    
-    private var loading = false {
+
+    private var loadingState: LoadingState = .connected {
         didSet {
             let activityIndicator = UIActivityIndicatorView(style: .gray)
             activityIndicator.startAnimating()
-            navigationItem.rightBarButtonItem = loading ? UIBarButtonItem(customView: activityIndicator) : nil
-//            title = loading ? "Connecting" : "Connected"
+
+            switch self.loadingState {
+            case .loading:
+                navigationItem.rightBarButtonItem = UIBarButtonItem(customView: activityIndicator)
+                title = "Connecting"
+            case .connected:
+                navigationItem.rightBarButtonItem = nil
+                title = "Connected"
+            case .error(_):
+                navigationItem.rightBarButtonItem = nil
+                title = "Connection error"
+            }
         }
     }
-    
+
     let connection = BluetoothConnection.shared
     lazy var characteristic = try! Characteristic(uuid: "1104FD87-820F-438A-B757-7AC2C15C2D56", shouldObserveNotification: true)
     lazy var otherCharacteristic = try! Characteristic(uuid: "1204FD87-820F-438A-B757-7AC2C15C2D56", shouldObserveNotification: true)
@@ -31,14 +41,16 @@ class ConnectionViewController: UIViewController {
     }()
     
     @IBAction func connect() {
-        loading = true
+        loadingState = .loading
         connection.connect(peripheral) { [weak self] error in
-            guard error == nil else {
+            if let error = error {
+                self?.loadingState = .error(error)
                 self?.title = "Connection failure"
                 return
+            } else {
+                self?.title = "Connected"
+                self?.loadingState = .connected
             }
-            self?.title = "Connected"
-            self?.loading = false
         }
         handleNotifications()
     }
@@ -81,5 +93,15 @@ class ConnectionViewController: UIViewController {
     
     @IBAction func hideKeyboard() {
         view.endEditing(true)
+    }
+}
+
+internal extension ConnectionViewController {
+
+    /// Enum representing current state of connecting to the peripheral.
+    enum LoadingState {
+        case loading
+        case connected
+        case error(Error)
     }
 }

--- a/Bluetooth/ConnectionViewController.swift
+++ b/Bluetooth/ConnectionViewController.swift
@@ -17,7 +17,7 @@ class ConnectionViewController: UIViewController {
             let activityIndicator = UIActivityIndicatorView(style: .gray)
             activityIndicator.startAnimating()
             navigationItem.rightBarButtonItem = loading ? UIBarButtonItem(customView: activityIndicator) : nil
-            title = loading ? "Connecting" : "Connected"
+//            title = loading ? "Connecting" : "Connected"
         }
     }
     
@@ -32,7 +32,12 @@ class ConnectionViewController: UIViewController {
     
     @IBAction func connect() {
         loading = true
-        connection.connect(peripheral) { [weak self] _ in
+        connection.connect(peripheral) { [weak self] error in
+            guard error == nil else {
+                self?.title = "Connection failure"
+                return
+            }
+            self?.title = "Connected"
             self?.loading = false
         }
         handleNotifications()
@@ -49,7 +54,7 @@ class ConnectionViewController: UIViewController {
             self?.notifyLabel.text = "Notify result: \(encoded)"
         }
     }
-    
+
     @IBAction func write() {
         let command = Command.utf8String(textField.text!)
         peripheral.write(command: command, characteristic: otherCharacteristic) { error in

--- a/Bluetooth/Supporting Files/Main.storyboard
+++ b/Bluetooth/Supporting Files/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kEX-h7-8hn">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kEX-h7-8hn">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -15,7 +13,7 @@
             <objects>
                 <navigationController id="kEX-h7-8hn" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="9M2-TF-UyM">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -35,7 +33,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="hQT-YX-G5g">
-                                <rect key="frame" x="134" y="278.5" width="106" height="110"/>
+                                <rect key="frame" x="134.5" y="278.5" width="106" height="110"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1W5-pn-g4j">
                                         <rect key="frame" x="0.0" y="0.0" width="106" height="30"/>
@@ -76,7 +74,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="oWa-Jl-NK6">
-                                <rect key="frame" x="37.5" y="103.5" width="300" height="300.5"/>
+                                <rect key="frame" x="37.5" y="99.5" width="300" height="308.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aGg-ff-DJc">
                                         <rect key="frame" x="0.0" y="0.0" width="300" height="30"/>
@@ -86,26 +84,24 @@
                                         </connections>
                                     </button>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Value that should be notified." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L1e-1Q-bec">
-                                        <rect key="frame" x="0.0" y="70" width="300" height="30"/>
-                                        <nil key="textColor"/>
+                                        <rect key="frame" x="0.0" y="70" width="300" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hwS-3g-E4Y">
-                                        <rect key="frame" x="0.0" y="140" width="300" height="30"/>
+                                        <rect key="frame" x="0.0" y="144" width="300" height="30"/>
                                         <state key="normal" title="Send notification!"/>
                                         <connections>
                                             <action selector="update" destination="hEK-kS-TRu" eventType="touchUpInside" id="mVu-eJ-pi9"/>
                                         </connections>
                                     </button>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Value that should be read." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2G6-hd-DUd">
-                                        <rect key="frame" x="0.0" y="210" width="300" height="30"/>
-                                        <nil key="textColor"/>
+                                        <rect key="frame" x="0.0" y="214" width="300" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Log:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NMI-Cn-f06">
-                                        <rect key="frame" x="0.0" y="280" width="300" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="288" width="300" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -113,7 +109,7 @@
                                 </subviews>
                             </stackView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="dSo-c5-C1d">
-                                <rect key="frame" x="37" y="414" width="300" height="200"/>
+                                <rect key="frame" x="37.5" y="418" width="300" height="200"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="200" id="MiW-3k-0Fb"/>
@@ -155,13 +151,13 @@
         <!--Connection View Controller-->
         <scene sceneID="9QC-iW-zk4">
             <objects>
-                <viewController id="0eC-V9-5DZ" customClass="ConnectionViewController" customModule="Bluetooth_Demo" sceneMemberID="viewController">
+                <viewController id="0eC-V9-5DZ" customClass="ConnectionViewController" customModule="BlueSwiftSample" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="HT6-Lc-Q64">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="tD4-dv-mGE">
-                                <rect key="frame" x="37.5" y="153.5" width="300" height="361"/>
+                                <rect key="frame" x="37.5" y="151" width="300" height="365"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PxK-tF-iWY">
                                         <rect key="frame" x="0.0" y="0.0" width="300" height="30"/>
@@ -171,33 +167,32 @@
                                         </connections>
                                     </button>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Value to write to peripheral." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XYB-JQ-M7G">
-                                        <rect key="frame" x="0.0" y="70" width="300" height="30"/>
-                                        <nil key="textColor"/>
+                                        <rect key="frame" x="0.0" y="70" width="300" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dnn-gX-BYB">
-                                        <rect key="frame" x="0.0" y="140" width="300" height="30"/>
+                                        <rect key="frame" x="0.0" y="144" width="300" height="30"/>
                                         <state key="normal" title="Send!"/>
                                         <connections>
                                             <action selector="write" destination="0eC-V9-5DZ" eventType="touchUpInside" id="oKG-gh-32H"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ibe-dQ-lHh">
-                                        <rect key="frame" x="0.0" y="210" width="300" height="30"/>
+                                        <rect key="frame" x="0.0" y="214" width="300" height="30"/>
                                         <state key="normal" title="Read!"/>
                                         <connections>
                                             <action selector="read" destination="0eC-V9-5DZ" eventType="touchUpInside" id="wcg-zc-68h"/>
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Read result" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tbA-58-6gg">
-                                        <rect key="frame" x="0.0" y="280" width="300" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="284" width="300" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Notify result" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zwt-Fx-l1k">
-                                        <rect key="frame" x="0.0" y="340.5" width="300" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="344.5" width="300" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -57,8 +57,15 @@ extension ConnectionService {
         if connectionHandler == nil {
             connectionHandler = handler
         }
-        peripherals.append(peripheral)
-        reloadScanning()
+        do {
+            try centralManager.validateState()
+            peripherals.append(peripheral)
+            reloadScanning()
+        } catch let error {
+            if let error = error as? BluetoothError {
+                handler(peripheral, .bluetoothError(error))
+            }
+        }
     }
     
     /// Disconnects given device.


### PR DESCRIPTION
### Title
<!-- In a few words, please provide a short title of proposed change. -->
Check whether Bluetooth is switched on, if not, pass appropriate error to handler.

I also fixed the faulty storyboard which was causing crash and blocked from testing the app with UI.
### Motivation

In one of my projects I needed to display message, when bluetooth is not turned on. 
### Solution
The device is trying to sync with peripheral by calling following function: 
`   public func connect(_ peripheral: Peripheral<Connectable>, handler: ((ConnectionError?) -> ())?)`
When bluetooth is switched off, instead of passing apropiate error to the handler, the request is timed out, because the flow assuming that it's switched on. 
This PR fixes that.