### PR TITLE
Add error separate code when there's no permission for bluetooth

### DIFF
--- a/Framework/Source Files/Extensions/CBManager.swift
+++ b/Framework/Source Files/Extensions/CBManager.swift
@@ -11,8 +11,10 @@ internal extension CBManager {
     /// Validates the current state of CBManager class to determine if Bluetooth is not supported on this device or is turned off or unavailable for some other reason.
     func validateState() throws {
         switch state {
-        case .poweredOff, .resetting, .unauthorized:
+        case .poweredOff, .resetting:
             throw BluetoothError.bluetoothUnavailable
+        case .unauthorized:
+            throw BluetoothError.unauthorized
         case .unsupported, .unknown:
             throw BluetoothError.incompatibleDevice
         default:

--- a/Framework/Source Files/Model/BluetoothError.swift
+++ b/Framework/Source Files/Model/BluetoothError.swift
@@ -9,6 +9,7 @@ import Foundation
 public enum BluetoothError: Error {
     case bluetoothUnavailable
     case incompatibleDevice
+    case unauthorized
 }
 
 /// List of possible errors during advertisement.


### PR DESCRIPTION
### Title
Add error separate code when there's no permission for bluetooth
### Motivation
I need to display the reason for not connecting with the device and handle UI accordingly. 
There was a generic `.bluetoothUnavailable` error before.
