### PR TITLE
Fix status unknown problem

### DIFF
--- a/Framework/Source Files/Connection/BluetoothConnection.swift
+++ b/Framework/Source Files/Connection/BluetoothConnection.swift
@@ -13,7 +13,7 @@ public final class BluetoothConnection: NSObject {
     public static let shared = BluetoothConnection()
     
     /// Connection service implementing native CoreBluetooth stack.
-    private lazy var connectionService = ConnectionService()
+    private var connectionService = ConnectionService()
     
     /// A advertisement validation handler. Will be called upon every peripheral discovery. Return value from this closure
     /// will indicate if manager should or shouldn't start connection with the passed peripheral according to it's identifier

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -44,14 +44,14 @@ internal final class ConnectionService: NSObject {
     private lazy var scanningOptions = [CBCentralManagerScanOptionAllowDuplicatesKey : true]
     
     /// CBCentralManager instance. Allows peripheral connection.
-    private var centralManager: CBCentralManager!
+    private let centralManager = CBCentralManager()
     
     /// Set of advertisement UUID central manager should scan for.
     private var scanParameters: Set<CBUUID> = Set()
 
     override init() {
         super.init()
-        centralManager = CBCentralManager(delegate: self, queue: .main)
+        centralManager.delegate = self
     }
 }
 

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -44,10 +44,15 @@ internal final class ConnectionService: NSObject {
     private lazy var scanningOptions = [CBCentralManagerScanOptionAllowDuplicatesKey : true]
     
     /// CBCentralManager instance. Allows peripheral connection.
-    private lazy var centralManager = CBCentralManager(delegate: self, queue: DispatchQueue.main, options: nil)
+    private var centralManager: CBCentralManager!
     
     /// Set of advertisement UUID central manager should scan for.
     private var scanParameters: Set<CBUUID> = Set()
+
+    override init() {
+        super.init()
+        centralManager = CBCentralManager(delegate: self, queue: .main)
+    }
 }
 
 extension ConnectionService {


### PR DESCRIPTION
### Title
Fix status **.unknown** returned by CBManager  at first `startScan()` call.

### Motivation
When user starts scanning for a device and an error occurs (such as bluetooth switched off, or permissions not set) CBManager sets it status to **.unknown**. The reasoning behind that is the fact that `CBCentralManager` will return the **.unknown** state if the initialization hasn't finished yet.

### Task Description
intialization is not finished at first  `startScan()` call, because `ConnectionService` and `CBCentralManager` was marked as lazy initialized. 
This PR fixes that.
