### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.4
+ import PackageDescription
+
+ let package = Package(
+     name: "BlueSwift",
+     platforms: [ .iOS(.v9) ],
+     products: [
+         .library(
+             name: "BlueSwift",
+             targets: ["BlueSwift"]),
+     ],    
+     targets: [
+         .target(
+             name: "BlueSwift",
+             path: "BlueSwiftKit"
+         ),
+         .testTarget(name: "BlueSwiftTests",
+                     dependencies: ["BlueSwift"],
+                     path: "Tests/BlueSwiftKitTests"
+         ),
+     ]
+ )

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 
  let package = Package(
      name: "BlueSwift",
-     platforms: [ .iOS(.v9) ],
+     platforms: [ .iOS(.v10) ],
      products: [
          .library(
              name: "BlueSwift",

--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,11 @@
      targets: [
          .target(
              name: "BlueSwift",
-             path: "BlueSwiftKit"
+             path: "Framework/Source Files"
          ),
          .testTarget(name: "BlueSwiftTests",
                      dependencies: ["BlueSwift"],
-                     path: "Tests/BlueSwiftKitTests"
+                     path: "Unit Tests"
          ),
      ]
  )


### PR DESCRIPTION
### Title
Add Swift Package Manager support

### Motivation
Cocoapods and Carthage are rarely used anymore. Swift Package Manager is the default for new projects and should be supported.

### Task Description
Developers should now be able to use SPM for projects, once a version bump occurs


Closes #40 