### PR TITLE
Add handler for peripheral connection cancelled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 xcuserdata
 profile
 build
+.build
 output
 DerivedData
 *.mode1v3

--- a/BlueSwift.podspec
+++ b/BlueSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name = 'BlueSwift'
-  spec.version = '1.0.5'
+  spec.version = '1.0.6'
   spec.summary = 'Easy and lightweight CoreBluetooth wrapper written in Swift'
   spec.homepage = 'https://github.com/netguru/BlueSwift'
 

--- a/Bluetooth.xcodeproj/project.pbxproj
+++ b/Bluetooth.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		38FE6BE7200689AB00809A06 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FE6BA82006898100809A06 /* ConfigurationTests.swift */; };
 		3A369634210F1C4E007C62F1 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A369633210F1C4E007C62F1 /* CoreBluetooth.framework */; };
 		3A369636210F1C57007C62F1 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A369635210F1C57007C62F1 /* XCTest.framework */; };
+		4BEB6E6F2800735D0061C702 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEB6E6E2800735D0061C702 /* Sequence.swift */; };
+		4BEB6E72280077010061C702 /* SequenceExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -150,6 +152,8 @@
 		3A142D24210F0EEE000A6089 /* Sample-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Sample-Base.xcconfig"; sourceTree = "<group>"; };
 		3A369633210F1C4E007C62F1 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.4.sdk/System/Library/Frameworks/CoreBluetooth.framework; sourceTree = DEVELOPER_DIR; };
 		3A369635210F1C57007C62F1 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		4BEB6E6E2800735D0061C702 /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
+		4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceExtensionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -306,6 +310,7 @@
 			isa = PBXGroup;
 			children = (
 				38FE6BA72006898100809A06 /* ExtensionTests.swift */,
+				4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */,
 				382CD41E2028F4B50065DFF6 /* CommandTests.swift */,
 				38FE6BA82006898100809A06 /* ConfigurationTests.swift */,
 				38FE6BA92006898100809A06 /* Info.plist */,
@@ -387,6 +392,7 @@
 				38FE6BBB2006898100809A06 /* CBUUID.swift */,
 				38FE6BBC2006898100809A06 /* String.swift */,
 				385B01AC2007C93000E3D478 /* Array.swift */,
+				4BEB6E6E2800735D0061C702 /* Sequence.swift */,
 				3863BE73200D582600FD4EC9 /* Int.swift */,
 				3863BE75200D5B9B00FD4EC9 /* Data.swift */,
 				3863BE68200BDDBA00FD4EC9 /* CBCharacteristic.swift */,
@@ -620,6 +626,7 @@
 			files = (
 				38BE35DC203DD67D0018EA0D /* ConnectablePeripheral.swift in Sources */,
 				3863BE69200BDDBA00FD4EC9 /* CBCharacteristic.swift in Sources */,
+				4BEB6E6F2800735D0061C702 /* Sequence.swift in Sources */,
 				385B01AD2007C93000E3D478 /* Array.swift in Sources */,
 				38FE6BD82006898100809A06 /* String.swift in Sources */,
 				382CD41C2028E5950065DFF6 /* Int.swift in Sources */,
@@ -645,6 +652,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4BEB6E72280077010061C702 /* SequenceExtensionTests.swift in Sources */,
 				382CD41F2028F4B50065DFF6 /* CommandTests.swift in Sources */,
 				38FE6BE7200689AB00809A06 /* ConfigurationTests.swift in Sources */,
 				38FE6BE6200689A700809A06 /* ExtensionTests.swift in Sources */,

--- a/Bluetooth/ConnectionViewController.swift
+++ b/Bluetooth/ConnectionViewController.swift
@@ -7,7 +7,7 @@ import UIKit
 import BlueSwift
 
 class ConnectionViewController: UIViewController {
-    
+
     @IBOutlet weak var notifyLabel: UILabel!
     @IBOutlet weak var readLabel: UILabel!
     @IBOutlet weak var textField: UITextField!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+    
+## [1.0.6] - 2022-04-08
+
+### Added
+
+- added public `peripheralConnectionCancelledHandler(_:)` setable property to `BluetoothConnection` class. It is called when disconnecting a peripheral using `disconnect(_:)` is completed
+
+### Changed
+
+- refactored `.filter(_:).first` to `first(where:)` for optimisation

--- a/Configurations/Common/Common-Base.xcconfig
+++ b/Configurations/Common/Common-Base.xcconfig
@@ -5,7 +5,7 @@
 
 #include "../xcconfigs/Common/Common.xcconfig"
 
-_BUILD_VERSION = 1.0.0
+_BUILD_VERSION = 1.0.6
 _BUILD_NUMBER = 1
 
 _DEPLOYMENT_TARGET_IOS = 11.0

--- a/Framework/Source Files/Connection/BluetoothConnection.swift
+++ b/Framework/Source Files/Connection/BluetoothConnection.swift
@@ -8,13 +8,13 @@ import CoreBluetooth
 
 /// Public facing interface granting methods to connect and disconnect devices.
 public final class BluetoothConnection: NSObject {
-    
+
     /// A singleton instance.
     public static let shared = BluetoothConnection()
-    
+
     /// Connection service implementing native CoreBluetooth stack.
     private var connectionService = ConnectionService()
-    
+
     /// A advertisement validation handler. Will be called upon every peripheral discovery. Return value from this closure
     /// will indicate if manager should or shouldn't start connection with the passed peripheral according to it's identifier
     /// and advertising packet.
@@ -34,7 +34,15 @@ public final class BluetoothConnection: NSObject {
             connectionService.peripheralValidationHandler = peripheralValidationHandler
         }
     }
-    
+
+    /// A peripheral connection cancelled handler. Called when disconnecting a peripheral using `disconnect(_:)` is completed.
+    /// Contains matched peripheral and native peripheral from CoreBluetooth.
+    public var peripheralConnectionCancelledHandler: ((Peripheral<Connectable>, CBPeripheral) -> Void)? {
+        didSet {
+            connectionService.peripheralConnectionCancelledHandler = peripheralConnectionCancelledHandler
+        }
+    }
+
     /// Primary method used to connect to a device. Can be called multiple times to connect more than on device at the same time.
     ///
     /// - Parameters:
@@ -56,7 +64,7 @@ public final class BluetoothConnection: NSObject {
             handler?(error)
         }
     }
-    
+
     /// Primary method to disconnect a device. If it's not yet connected it'll be removed from connection queue, and connection attempts will stop.
     ///
     /// - Parameter peripheral: a peripheral you wish to disconnect. Should be exactly the same instance that was used for connection.

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -82,7 +82,8 @@ extension ConnectionService {
     /// Disconnects given device.
     internal func disconnect(_ peripheral: CBPeripheral) {
         if let index = peripherals.firstIndex(where: { $0.peripheral === peripheral }) {
-            peripheralsToDisconnect.append(peripherals.remove(at: index))
+            let peripheralToDisconnect = peripherals.remove(at: index)
+            peripheralsToDisconnect.append(peripheralToDisconnect)
         }
         centralManager.cancelPeripheralConnection(peripheral)
     }
@@ -176,7 +177,7 @@ extension ConnectionService: CBCentralManagerDelegate {
     /// Called upon a successfull peripheral connection.
     /// - SeeAlso: CBCentralManagerDelegate
     public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        guard let connectingPeripheral = peripherals.first(where: { $0.peripheral === peripheral }) else { return }
+        guard let connectingPeripheral = peripherals.first(withIdentical: peripheral) else { return }
         self.connectingPeripheral = connectingPeripheral
         connectingPeripheral.peripheral = peripheral
         peripheral.delegate = self
@@ -239,13 +240,13 @@ extension ConnectionService: CBPeripheralDelegate {
         /// `error` is nil if disconnect resulted from a call to `cancelPeripheralConnection(_:)`.
         /// SeeAlso: https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/1518791-centralmanager
         if error == nil,
-           let disconnectedPeripheral = peripheralsToDisconnect.first(where: { $0.peripheral === peripheral }) {
+           let disconnectedPeripheral = peripheralsToDisconnect.first(withIdentical: peripheral) {
             peripheralsToDisconnect.removeAll(where: { $0 === disconnectedPeripheral })
             peripheralConnectionCancelledHandler?(disconnectedPeripheral, peripheral)
             return
         }
         
-        if let disconnectedPeripheral = peripherals.first(where: { $0.peripheral === peripheral }),
+        if let disconnectedPeripheral = peripherals.first(withIdentical: peripheral),
            let nativePeripheral = disconnectedPeripheral.peripheral {
             disconnectedPeripheral.disconnectionHandler?()
             centralManager.connect(nativePeripheral, options: connectionOptions)

--- a/Framework/Source Files/Extensions/Sequence.swift
+++ b/Framework/Source Files/Extensions/Sequence.swift
@@ -1,0 +1,41 @@
+//
+//  Sequence.swift
+//  Bluetooth
+//
+//  Created by Filip Zieliński on 08/04/2022.
+//  Copyright © 2022 Netguru. All rights reserved.
+//
+
+import Foundation
+import CoreBluetooth
+
+internal extension Sequence {
+
+    /// Returns the first element of the sequence where given element property is identical (`===`) to given object instance.
+    /// - Parameters:
+    ///   - propertyKeyPath: a key path to an element property.
+    ///   - instance: an object instance to compare against.
+    /// - Returns: The first element of the sequence where given element property is identical (`===`) to given object instance, or `nil` if there is no such element.
+    func first<Object: AnyObject>(where propertyKeyPath: KeyPath<Element, Object>, isIdenticalTo instance: Object) -> Element? {
+        first { $0[keyPath: propertyKeyPath] === instance }
+    }
+
+    /// Returns the first element of the sequence where given element optional property is identical (`===`) to given object instance.
+    /// - Parameters:
+    ///   - propertyKeyPath: a key path to an element property.
+    ///   - instance: an object instance to compare against.
+    /// - Returns: The first element of the sequence where given element optional property is identical (`===`) to given object instance, or `nil` if there is no such element.
+    func first<Object: AnyObject>(where propertyKeyPath: KeyPath<Element, Object?>, isIdenticalTo instance: Object) -> Element? {
+        first { $0[keyPath: propertyKeyPath] === instance }
+    }
+}
+
+internal extension Sequence where Element == Peripheral<Connectable> {
+
+    /// Convenience method returning the first peripheral of the sequence with `peripheral` property identical (`===`)  to given `CBPeripheral` instance.
+    /// - Parameter cbPeripheral: a `CBPeripheral` instance.
+    /// - Returns: The first peripheral of the sequence with `peripheral` property identical (`===`)  to given `CBPeripheral` instance, or `nil` if there is no such element.
+    func first(withIdentical cbPeripheral: CBPeripheral) -> Element? {
+        first(where: \.peripheral, isIdenticalTo: cbPeripheral)
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ Just drop the line below to your Podfile:
 
 `pod 'BlueSwift'`
 
-(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.0.0'`)
+(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.0.6'`)
 
 ### ![](https://img.shields.io/badge/carthage-compatible-green.svg)
 
@@ -103,7 +103,7 @@ The same as with Cocoapods, insert the line below to your Cartfile:
 
 `github 'netguru/BlueSwift'`
 
-, or including version - `github 'netguru/BlueSwift' ~> 1.0.0`
+, or including version - `github 'netguru/BlueSwift' ~> 1.0.6`
 
 ## 📄 License
 

--- a/Unit Tests/SequenceExtensionTests.swift
+++ b/Unit Tests/SequenceExtensionTests.swift
@@ -1,0 +1,78 @@
+//
+//  SequenceExtensionTests.swift
+//  Bluetooth
+//
+//  Created by Filip Zieliński on 08/04/2022.
+//  Copyright © 2022 Netguru. All rights reserved.
+//
+
+import XCTest
+import CoreBluetooth
+@testable import BlueSwift
+
+final class SequenceExtensionTests: XCTestCase {
+
+    private let fixtureReference = SimpleClass()
+    private let fixtureOptionalReference = SimpleClass()
+    private lazy var fixtureTestClass = TestClass(someReference: fixtureReference, someOptionalReference: fixtureOptionalReference)
+
+    func testFirstSequenceElement_withIdenticalProperty() {
+        // given:
+        var sut: [TestClass] = [
+            TestClass(someReference: .init(), someOptionalReference: nil),
+            TestClass(someReference: .init(), someOptionalReference: .init()),
+            fixtureTestClass,
+            TestClass(someReference: .init(), someOptionalReference: .init()),
+        ]
+
+        // then:
+        testFindingElement_withMatchingIdenticalProperty(sut: sut)
+
+        // given
+        sut = [
+            fixtureTestClass,
+            TestClass(someReference: .init(), someOptionalReference: .init()),
+            TestClass(someReference: .init(), someOptionalReference: .init()),
+            TestClass(someReference: .init(), someOptionalReference: nil)
+        ]
+
+        // then:
+        testFindingElement_withMatchingIdenticalProperty(sut: sut)
+
+        // given
+        sut = [
+            TestClass(someReference: .init(), someOptionalReference: .init()),
+            TestClass(someReference: .init(), someOptionalReference: nil),
+            TestClass(someReference: .init(), someOptionalReference: .init()),
+            fixtureTestClass
+        ]
+
+        // then:
+        testFindingElement_withMatchingIdenticalProperty(sut: sut)
+    }
+}
+
+private extension SequenceExtensionTests {
+
+    func testFindingElement_withMatchingIdenticalProperty(sut: [TestClass]) {
+        XCTAssert(sut.first(where: \.someReference, isIdenticalTo: fixtureReference) === fixtureTestClass, "Should find object with matching identical (`===`) property")
+        XCTAssert(sut.first(where: \.someOptionalReference, isIdenticalTo: fixtureOptionalReference) === fixtureTestClass, "Should find object with matching identical (`===`) property")
+        XCTAssertNil(sut.first(where: \.someReference, isIdenticalTo: fixtureOptionalReference), "Should not find any object with matching identical (`===`) property")
+        XCTAssertNil(sut.first(where: \.someOptionalReference, isIdenticalTo: fixtureReference), "Should not find any object with matching identical (`===`) property")
+        XCTAssertNil(sut.first(where: \.someReference, isIdenticalTo: .init()), "Should not find any object with matching identical (`===`) property")
+        XCTAssertNil(sut.first(where: \.someOptionalReference, isIdenticalTo: .init()), "Should not find any object with matching identical (`===`) property")
+    }
+}
+
+private final class TestClass: Identifiable {
+
+    let someReference: SimpleClass
+    let someOptionalReference: SimpleClass?
+    
+    init(someReference: SimpleClass, someOptionalReference: SimpleClass?) {
+        self.someReference = someReference
+        self.someOptionalReference = someOptionalReference
+    }
+}
+
+private final class SimpleClass {}

--- a/docs/bluetoothConnection.md
+++ b/docs/bluetoothConnection.md
@@ -22,6 +22,13 @@ Advertising is passed in `[String: Any]` dictionary. This data is sent along wit
 If false is returned from this method, no attempt to connect a given peripheral will we attempted.
 
 ```swift
+var peripheralConnectionCancelledHandler: ((Peripheral<Connectable>, CBPeripheral) -> Void)?
+```
+
+An optional closure, nil by default - peripheral connection cancelled handler. Called when disconnecting a peripheral using `disconnect(_:)` is completed.
+Contains matched peripheral and native peripheral from CoreBluetooth.
+
+```swift
 func connect(_ peripheral: Peripheral<Connectable>, handler: ((ConnectionError?) -> ())?)
 ```
 


### PR DESCRIPTION
### Title
Add handler for peripheral connection cancelled.

### Motivation
A project I'm working on needs to be notified when disconnecting a peripheral completes (so after calling `disconnect(_:)`, when CoreBluetooth completes disconnecting).

### Task Description
- add public `peripheralConnectionCancelledHandler(_:)` settable property
- refactor from `.filter(_:).first` to `first(where:)` for optimization
- bump version to 1.0.6
- add project change log