### PR TITLE
Enable library evolution

### DIFF
--- a/BlueSwift.podspec
+++ b/BlueSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name = 'BlueSwift'
-  spec.version = '1.0.6'
+  spec.version = '1.1.0'
   spec.summary = 'Easy and lightweight CoreBluetooth wrapper written in Swift'
   spec.homepage = 'https://github.com/netguru/BlueSwift'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
-    
+
+
+## [1.1.0] - 2022-04-13
+
+### Changed
+
+- enabled Swift library evolution (`BUILD_LIBRARY_FOR_DISTRIBUTION = YES`) to allow creating XCFrameworks using BlueSwift. See ["Library Evolution in Swift"](https://www.swift.org/blog/library-evolution/) official swift blogpost.
+This change:
+    - allows modules built with different compiler versions to be used together in one app.
+    - allows developers of binary frameworks to make additive changes to the API of their framework while remaining binary compatible with previous versions.
+
 ## [1.0.6] - 2022-04-08
 
 ### Added

--- a/Configurations/Common/Common-Base.xcconfig
+++ b/Configurations/Common/Common-Base.xcconfig
@@ -5,7 +5,7 @@
 
 #include "../xcconfigs/Common/Common.xcconfig"
 
-_BUILD_VERSION = 1.0.6
+_BUILD_VERSION = 1.1.0
 _BUILD_NUMBER = 1
 
 _DEPLOYMENT_TARGET_IOS = 11.0

--- a/Configurations/Framework/Framework-Base.xcconfig
+++ b/Configurations/Framework/Framework-Base.xcconfig
@@ -11,3 +11,6 @@ _BUNDLE_IDENTIFIER = co.netguru.lib.blueswift
 _BUNDLE_INFOPLIST_PATH = $(PROJECT_DIR)/Framework/Supporting Files/Info.plist
 
 ENABLE_TESTABILITY = YES
+
+// Build library for distribution to enable Swift library evolution
+BUILD_LIBRARY_FOR_DISTRIBUTION = YES

--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ Just drop the line below to your Podfile:
 
 `pod 'BlueSwift'`
 
-(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.0.6'`)
+(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.1.0'`)
 
 ### ![](https://img.shields.io/badge/carthage-compatible-green.svg)
 
@@ -103,7 +103,7 @@ The same as with Cocoapods, insert the line below to your Cartfile:
 
 `github 'netguru/BlueSwift'`
 
-, or including version - `github 'netguru/BlueSwift' ~> 1.0.6`
+, or including version - `github 'netguru/BlueSwift' ~> 1.1.0`
 
 ## 📄 License
 


### PR DESCRIPTION
### Title
Enable library evolution

### Motivation
Enabled Swift library evolution to remain binary compatible with different library versions.

### Task Description
Set build configuration `BUILD_LIBRARY_FOR_DISTRIBUTION = YES`.
