### PR TITLE
Delay iOS Bluetooth authorisation popup

### DIFF
--- a/BlueSwift.podspec
+++ b/BlueSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name = 'BlueSwift'
-  spec.version = '1.1.0'
+  spec.version = '1.1.1'
   spec.summary = 'Easy and lightweight CoreBluetooth wrapper written in Swift'
   spec.homepage = 'https://github.com/netguru/BlueSwift'
 

--- a/Bluetooth.xcodeproj/project.pbxproj
+++ b/Bluetooth.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		38FE6BE7200689AB00809A06 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FE6BA82006898100809A06 /* ConfigurationTests.swift */; };
 		3A369634210F1C4E007C62F1 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A369633210F1C4E007C62F1 /* CoreBluetooth.framework */; };
 		3A369636210F1C57007C62F1 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A369635210F1C57007C62F1 /* XCTest.framework */; };
+		4B62466A280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B624669280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift */; };
 		4BEB6E6F2800735D0061C702 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEB6E6E2800735D0061C702 /* Sequence.swift */; };
 		4BEB6E72280077010061C702 /* SequenceExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */; };
 /* End PBXBuildFile section */
@@ -152,6 +153,7 @@
 		3A142D24210F0EEE000A6089 /* Sample-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Sample-Base.xcconfig"; sourceTree = "<group>"; };
 		3A369633210F1C4E007C62F1 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.4.sdk/System/Library/Frameworks/CoreBluetooth.framework; sourceTree = DEVELOPER_DIR; };
 		3A369635210F1C57007C62F1 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		4B624669280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothAuthorizationStatus.swift; sourceTree = "<group>"; };
 		4BEB6E6E2800735D0061C702 /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
 		4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceExtensionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -410,6 +412,7 @@
 				38FE6BC12006898100809A06 /* Configuration.swift */,
 				382516552049899F0097F9D7 /* AdvertisementData.swift */,
 				3825165720498C450097F9D7 /* BluetoothError.swift */,
+				4B624669280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -624,6 +627,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4B62466A280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift in Sources */,
 				38BE35DC203DD67D0018EA0D /* ConnectablePeripheral.swift in Sources */,
 				3863BE69200BDDBA00FD4EC9 /* CBCharacteristic.swift in Sources */,
 				4BEB6E6F2800735D0061C702 /* Sequence.swift in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.1.1] - 2022-04-14
+
+### Added
+
+- `bluetoothAuthorizationStatus` public property was added to `BluetoothConnection` to determine current Bluetooth authorization status.
+- `requestBluetoothAuthorization()` public method was added to `BluetoothConnection` to requests User for authorization to use Bluetooth.
+- `BluetoothAuthorizationStatus` enum describing Bluetooth authorization status
+
+### Changed
+
+- `ConnectionService`: centralManager (`CBCentralManager`) is instantiated lazily to postpone showing Bluetooth authorization popup until it is needed.
 
 ## [1.1.0] - 2022-04-13
 

--- a/Configurations/Common/Common-Base.xcconfig
+++ b/Configurations/Common/Common-Base.xcconfig
@@ -5,7 +5,7 @@
 
 #include "../xcconfigs/Common/Common.xcconfig"
 
-_BUILD_VERSION = 1.1.0
+_BUILD_VERSION = 1.1.1
 _BUILD_NUMBER = 1
 
 _DEPLOYMENT_TARGET_IOS = 11.0

--- a/Framework/Source Files/Connection/BluetoothConnection.swift
+++ b/Framework/Source Files/Connection/BluetoothConnection.swift
@@ -43,6 +43,11 @@ public final class BluetoothConnection: NSObject {
         }
     }
 
+    /// Current Bluetooth authorization status.
+    public var bluetoothAuthorizationStatus: BluetoothAuthorizationStatus {
+        connectionService.bluetoothAuthorizationStatus
+    }
+
     /// Primary method used to connect to a device. Can be called multiple times to connect more than on device at the same time.
     ///
     /// - Parameters:
@@ -79,5 +84,10 @@ public final class BluetoothConnection: NSObject {
     /// Function called to stop scanning for devices.
     public func stopScanning() {
         connectionService.stopScanning()
+    }
+
+    /// Requests User for authorization to use Bluetooth.
+    public func requestBluetoothAuthorization() {
+        connectionService.requestBluetoothAuthorization()
     }
 }

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -62,8 +62,8 @@ internal final class ConnectionService: NSObject {
     private lazy var scanningOptions = [CBCentralManagerScanOptionAllowDuplicatesKey : true]
     
     /// CBCentralManager instance. Allows peripheral connection.
+    /// iOS displays Bluetooth authorization popup when `CBCentralManager` is instantiated and authorization status is not determined.
     private lazy var centralManager: CBCentralManager = {
-        // iOS displays Bluetooth authorization popup when `CBCentralManager` is instantiated and authorization status is not determined.
         let manager = CBCentralManager()
         manager.delegate = self
         return manager

--- a/Framework/Source Files/Model/BluetoothAuthorizationStatus.swift
+++ b/Framework/Source Files/Model/BluetoothAuthorizationStatus.swift
@@ -1,0 +1,76 @@
+//
+//  Copyright © 2018 Netguru Sp. z o.o. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import CoreBluetooth
+
+/// The current authorization state of a Core Bluetooth manager.
+@objc public enum BluetoothAuthorizationStatus: Int {
+    /// Bluetooth authorization status is not determined.
+    case notDetermined = 0
+
+    /// Bluetooth connection is restricted.
+    case restricted = 1
+
+    /// Bluetooth connection is denied.
+    case denied = 2
+
+    /// Bluetooth connection is allowed always.
+    case allowedAlways = 3
+}
+
+@available(iOSApplicationExtension 13.0, *)
+extension BluetoothAuthorizationStatus {
+
+    /// `CBManagerAuthorization` representation of current authorization status.
+    var cbManagerAuthorization: CBManagerAuthorization {
+        switch self {
+        case .notDetermined:
+            return .notDetermined
+        case .restricted:
+            return .restricted
+        case .denied:
+            return .denied
+        case .allowedAlways:
+            return .allowedAlways
+        }
+    }
+}
+
+@available(iOSApplicationExtension 13.0, *)
+extension CBManagerAuthorization {
+
+    /// `BluetoothAuthorizationStatus` representation of current authorization status.
+    var bluetoothAuthorizationStatus: BluetoothAuthorizationStatus {
+        switch self {
+        case .notDetermined:
+            return .notDetermined
+        case .restricted:
+            return .restricted
+        case .denied:
+            return .denied
+        case .allowedAlways:
+            return .allowedAlways
+        @unknown default:
+            return .notDetermined
+        }
+    }
+}
+
+extension BluetoothAuthorizationStatus: CustomStringConvertible {
+
+    /// SeeAlso: `CustomStringConvertible.description`
+    public var description: String {
+        switch self {
+        case .notDetermined:
+            return "notDetermined"
+        case .restricted:
+            return "restricted"
+        case .denied:
+            return "denied"
+        case .allowedAlways:
+            return "allowedAlways"
+        }
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ Just drop the line below to your Podfile:
 
 `pod 'BlueSwift'`
 
-(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.1.0'`)
+(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.1.1'`)
 
 ### ![](https://img.shields.io/badge/carthage-compatible-green.svg)
 
@@ -103,7 +103,7 @@ The same as with Cocoapods, insert the line below to your Cartfile:
 
 `github 'netguru/BlueSwift'`
 
-, or including version - `github 'netguru/BlueSwift' ~> 1.1.0`
+, or including version - `github 'netguru/BlueSwift' ~> 1.1.1`
 
 ## 📄 License
 


### PR DESCRIPTION
### Title
Delay iOS Bluetooth authorization popup

### Motivation
iOS Bluetooth authorization popup should be displayed when Bluetooth connection is actually needed.

### Task Description
- instantiate `CBCentralManager` lazily
- add method for requesting Bluetooth authorization
- add `bluetoothAuthorizationStatus` public property