### PR TITLE
Change: `iOSApplicationExtension` → `iOS` in specifying platform.

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -33,9 +33,9 @@ internal final class ConnectionService: NSObject {
 
     /// Current Bluetooth authorization status.
     internal var bluetoothAuthorizationStatus: BluetoothAuthorizationStatus {
-        if #available(iOSApplicationExtension 13.1, *) {
+        if #available(iOS 13.1, *) {
             return CBManager.authorization.bluetoothAuthorizationStatus
-        } else if #available(iOSApplicationExtension 13.0, *) {
+        } else if #available(iOS 13.0, *) {
             return centralManager.authorization.bluetoothAuthorizationStatus
         } else {
             // Until iOS 12 applications could access Bluetooth without the user’s authorization

--- a/Framework/Source Files/Model/BluetoothAuthorizationStatus.swift
+++ b/Framework/Source Files/Model/BluetoothAuthorizationStatus.swift
@@ -20,7 +20,7 @@ import CoreBluetooth
     case allowedAlways = 3
 }
 
-@available(iOSApplicationExtension 13.0, *)
+@available(iOS 13.0, *)
 extension BluetoothAuthorizationStatus {
 
     /// `CBManagerAuthorization` representation of current authorization status.
@@ -38,7 +38,7 @@ extension BluetoothAuthorizationStatus {
     }
 }
 
-@available(iOSApplicationExtension 13.0, *)
+@available(iOS 13.0, *)
 extension CBManagerAuthorization {
 
     /// `BluetoothAuthorizationStatus` representation of current authorization status.


### PR DESCRIPTION
### Title

Change: `iOSApplicationExtension` → `iOS` in specifying platform.

### Motivation
<!-- Please describe why do you want to implement this change. -->

I changed `iOSApplicationExtension` specifier into `iOS` because it failed to compile on Xcode14.
<img width="1440" alt="スクリーンショット 2022-06-09 20 28 45" src="https://user-images.githubusercontent.com/44002126/172837087-76f0ef11-d629-42ee-a5b9-74cf827127cf.png">


### Task Description
<!-- What should and what actually happens. -->

In this state, I cloud not find the official reason why this change is necessary, but ordinarily `iOSApplicationExtension` should be used for app extensions like `Share Extension`, `Notiication Extension` and so on. That's why it is better to specify `iOS` platform availability than `iOSApplicationExtension`, I think.

---

Thank you for reading this proposal.