### PR TITLE
Allow monitoring Central Manager state updates

### DIFF
--- a/BlueSwift.podspec
+++ b/BlueSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name = 'BlueSwift'
-  spec.version = '1.1.1'
+  spec.version = '1.1.2'
   spec.summary = 'Easy and lightweight CoreBluetooth wrapper written in Swift'
   spec.homepage = 'https://github.com/netguru/BlueSwift'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.1.2] - 2022-09-06
+
+### Added
+
+- added settable `centralManagerStateUpdateHandler` public property to `BluetoothConnection` to monitor updates to Central Manager state.
+
 ## [1.1.1] - 2022-04-14
 
 ### Added

--- a/Configurations/Common/Common-Base.xcconfig
+++ b/Configurations/Common/Common-Base.xcconfig
@@ -5,7 +5,7 @@
 
 #include "../xcconfigs/Common/Common.xcconfig"
 
-_BUILD_VERSION = 1.1.1
+_BUILD_VERSION = 1.1.2
 _BUILD_NUMBER = 1
 
 _DEPLOYMENT_TARGET_IOS = 11.0

--- a/Framework/Source Files/Connection/BluetoothConnection.swift
+++ b/Framework/Source Files/Connection/BluetoothConnection.swift
@@ -15,7 +15,7 @@ public final class BluetoothConnection: NSObject {
     /// Connection service implementing native CoreBluetooth stack.
     private var connectionService = ConnectionService()
 
-    /// A advertisement validation handler. Will be called upon every peripheral discovery. Return value from this closure
+    /// An advertisement validation handler. Will be called upon every peripheral discovery. Return value from this closure
     /// will indicate if manager should or shouldn't start connection with the passed peripheral according to it's identifier
     /// and advertising packet.
     @available(*, deprecated, message: "This closure will be removed in future version. Please use `peripheralValidationHandler`.")
@@ -25,13 +25,21 @@ public final class BluetoothConnection: NSObject {
         }
     }
 
-    /// A advertisement validation handler. Will be called upon every peripheral discovery. Contains matched peripheral,
+    /// A peripheral validation handler. Will be called upon every peripheral discovery. Contains matched peripheral,
     /// discovered peripheral from CoreBluetooth, advertisement data and RSSI value. Return value from this closure
     /// will indicate if manager should or shouldn't start connection with the passed peripheral according to it's identifier
     /// and advertising packet.
     public var peripheralValidationHandler: ((Peripheral<Connectable>, CBPeripheral, [String: Any], NSNumber) -> (Bool))? {
         didSet {
             connectionService.peripheralValidationHandler = peripheralValidationHandler
+        }
+    }
+
+    /// Callback for update to Bluetooth sensor state for current device.
+    /// Assign custom block to this property to monitor Central Manager state changes (`poweredOn`,  `poweredOff`, `unauthorized` etc.).
+    public var centralManagerStateUpdateHandler: ((CBManagerState) -> Void)? {
+        didSet {
+            connectionService.centralManagerStateUpdateHandler = centralManagerStateUpdateHandler
         }
     }
 

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -21,6 +21,9 @@ internal final class ConnectionService: NSObject {
     /// Closure called when disconnecting a peripheral using `disconnect(_:)` is completed.
     internal var peripheralConnectionCancelledHandler: ((Peripheral<Connectable>, CBPeripheral) -> ())?
 
+    /// Called when Bluetooth sensor state for current device was updated.
+    internal var centralManagerStateUpdateHandler: ((CBManagerState) -> Void)?
+
     /// Returns the amount of devices already connected.
     internal var connectedDevicesAmount: Int {
         return peripherals.filter { $0.isConnected }.count
@@ -159,6 +162,8 @@ extension ConnectionService: CBCentralManagerDelegate {
     /// Determines Bluetooth sensor state for current device.
     /// - SeeAlso: CBCentralManagerDelegate
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        centralManagerStateUpdateHandler?(central.state)
+
         guard let handler = connectionHandler, let anyDevice = peripherals.first else { return }
         do {
             try central.validateState()

--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ Just drop the line below to your Podfile:
 
 `pod 'BlueSwift'`
 
-(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.1.1'`)
+(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.1.2'`)
 
 ### ![](https://img.shields.io/badge/carthage-compatible-green.svg)
 
@@ -103,7 +103,7 @@ The same as with Cocoapods, insert the line below to your Cartfile:
 
 `github 'netguru/BlueSwift'`
 
-, or including version - `github 'netguru/BlueSwift' ~> 1.1.1`
+, or including version - `github 'netguru/BlueSwift' ~> 1.1.2`
 
 ## 📄 License
 


### PR DESCRIPTION
### Title
Allow monitoring Central Manager state updates.

### Motivation
Currently, there is no way of checking Central Manager state without creating a separate `CBCentralManager` instance in SDK client app. This change adds this possibility.

### Task Description
Added settable `centralManagerStateUpdateHandler` public property to `BluetoothConnection` to monitor updates to Central Manager state.