### PR TITLE
Cancel unexpected peripheral connection

### DIFF
--- a/BlueSwift.podspec
+++ b/BlueSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name = 'BlueSwift'
-  spec.version = '1.1.2'
+  spec.version = '1.1.3'
   spec.summary = 'Easy and lightweight CoreBluetooth wrapper written in Swift'
   spec.homepage = 'https://github.com/netguru/BlueSwift'
 

--- a/Bluetooth.xcodeproj/project.pbxproj
+++ b/Bluetooth.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		38FE6BE7200689AB00809A06 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FE6BA82006898100809A06 /* ConfigurationTests.swift */; };
 		3A369634210F1C4E007C62F1 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A369633210F1C4E007C62F1 /* CoreBluetooth.framework */; };
 		3A369636210F1C57007C62F1 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A369635210F1C57007C62F1 /* XCTest.framework */; };
+		4B2ACCCD29083F4300EF10B6 /* Readme.md in Resources */ = {isa = PBXBuildFile; fileRef = 4B2ACCCC29083F4200EF10B6 /* Readme.md */; };
+		4B2ACCCF29083F5400EF10B6 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 4B2ACCCE29083F5400EF10B6 /* CHANGELOG.md */; };
 		4B62466A280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B624669280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift */; };
 		4BEB6E6F2800735D0061C702 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEB6E6E2800735D0061C702 /* Sequence.swift */; };
 		4BEB6E72280077010061C702 /* SequenceExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */; };
@@ -153,6 +155,8 @@
 		3A142D24210F0EEE000A6089 /* Sample-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Sample-Base.xcconfig"; sourceTree = "<group>"; };
 		3A369633210F1C4E007C62F1 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.4.sdk/System/Library/Frameworks/CoreBluetooth.framework; sourceTree = DEVELOPER_DIR; };
 		3A369635210F1C57007C62F1 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		4B2ACCCC29083F4200EF10B6 /* Readme.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Readme.md; sourceTree = "<group>"; };
+		4B2ACCCE29083F5400EF10B6 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		4B624669280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothAuthorizationStatus.swift; sourceTree = "<group>"; };
 		4BEB6E6E2800735D0061C702 /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
 		4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceExtensionTests.swift; sourceTree = "<group>"; };
@@ -190,6 +194,8 @@
 		3837BA021FFFC2FE00DF300E = {
 			isa = PBXGroup;
 			children = (
+				4B2ACCCC29083F4200EF10B6 /* Readme.md */,
+				4B2ACCCE29083F5400EF10B6 /* CHANGELOG.md */,
 				38FE6BC32006898100809A06 /* Bluetooth */,
 				38FE6BB32006898100809A06 /* Framework */,
 				38FE6BA62006898100809A06 /* Unit Tests */,
@@ -591,7 +597,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				38EBB9572052D0EF002797A1 /* Main.storyboard in Resources */,
+				4B2ACCCF29083F5400EF10B6 /* CHANGELOG.md in Resources */,
 				38FE6BE42006898F00809A06 /* Assets.xcassets in Resources */,
+				4B2ACCCD29083F4300EF10B6 /* Readme.md in Resources */,
 				38FE6BE52006899300809A06 /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.1.3] - 2022-10-25
+
+### Changed
+
+- Peripheral which was connected, but it was not on the list of peripherals that should be connected, is disconnected. This change allows to discover this peripheral again. 
+
 ## [1.1.2] - 2022-09-06
 
 ### Added

--- a/Configurations/Common/Common-Base.xcconfig
+++ b/Configurations/Common/Common-Base.xcconfig
@@ -5,7 +5,7 @@
 
 #include "../xcconfigs/Common/Common.xcconfig"
 
-_BUILD_VERSION = 1.1.2
+_BUILD_VERSION = 1.1.3
 _BUILD_NUMBER = 1
 
 _DEPLOYMENT_TARGET_IOS = 11.0

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -199,7 +199,12 @@ extension ConnectionService: CBCentralManagerDelegate {
     /// Called upon a successfull peripheral connection.
     /// - SeeAlso: CBCentralManagerDelegate
     public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        guard let connectingPeripheral = peripherals.first(withIdentical: peripheral) else { return }
+        guard let connectingPeripheral = peripherals.first(withIdentical: peripheral) else {
+            // Central manager did connect to a peripheral, which is not on the list of allowed peripherals at this moment.
+            // Peripheral might have re-connected unexpectedly. Disconnect it, so it can be discovered.
+            centralManager.cancelPeripheralConnection(peripheral)
+            return
+        }
         self.connectingPeripheral = connectingPeripheral
         connectingPeripheral.peripheral = peripheral
         peripheral.delegate = self

--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ Just drop the line below to your Podfile:
 
 `pod 'BlueSwift'`
 
-(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.1.2'`)
+(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.1.3'`)
 
 ### ![](https://img.shields.io/badge/carthage-compatible-green.svg)
 
@@ -103,7 +103,7 @@ The same as with Cocoapods, insert the line below to your Cartfile:
 
 `github 'netguru/BlueSwift'`
 
-, or including version - `github 'netguru/BlueSwift' ~> 1.1.2`
+, or including version - `github 'netguru/BlueSwift' ~> 1.1.3`
 
 ## 📄 License
 


### PR DESCRIPTION
### Cancel unexpected peripheral connection

### Motivation
Some connected peripherals, after they are turned off and on again, might instantly connect to central manager, even when scanning was stopped. Effectively, they skip the BlueSwift's start scanning and peripheral discovery phases. Because of that, "connected" device is not on the expected `peripherals` list, making the connected device unavailable to framework clients - see `didConnect` delegate method just returning when connected peripheral is absent from `peripherals` list.

### Task Description
This task disconnects an unexpectedly connected peripheral, allowing peripheral to start advertising again and be connected using regular flow.