### PR TITLE
Refactor removing peripheral from list

### DIFF
--- a/BlueSwift.podspec
+++ b/BlueSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name = 'BlueSwift'
-  spec.version = '1.1.3'
+  spec.version = '1.1.4'
   spec.summary = 'Easy and lightweight CoreBluetooth wrapper written in Swift'
   spec.homepage = 'https://github.com/netguru/BlueSwift'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.1.4] - 2023-01-04
+
+### Changed
+
+- Refactor array-index based removing peripheral from list of peripherals to connect with.
+
 ## [1.1.3] - 2022-10-25
 
 ### Changed

--- a/Configurations/Common/Common-Base.xcconfig
+++ b/Configurations/Common/Common-Base.xcconfig
@@ -5,7 +5,7 @@
 
 #include "../xcconfigs/Common/Common.xcconfig"
 
-_BUILD_VERSION = 1.1.3
+_BUILD_VERSION = 1.1.4
 _BUILD_NUMBER = 1
 
 _DEPLOYMENT_TARGET_IOS = 11.0

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -106,8 +106,7 @@ extension ConnectionService {
     /// Function called to remove peripheral from queue
     /// - Parameter peripheral: peripheral to remove.
     internal func remove(_ peripheral: Peripheral<Connectable>) {
-        guard let index = peripherals.firstIndex(where: { $0 === peripheral }) else { return }
-        peripherals.remove(at: index)
+        peripherals.removeAll { $0 === peripheral }
     }
 
     /// Function called to stop scanning for devices.

--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ Just drop the line below to your Podfile:
 
 `pod 'BlueSwift'`
 
-(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.1.3'`)
+(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.1.4'`)
 
 ### ![](https://img.shields.io/badge/carthage-compatible-green.svg)
 
@@ -103,7 +103,7 @@ The same as with Cocoapods, insert the line below to your Cartfile:
 
 `github 'netguru/BlueSwift'`
 
-, or including version - `github 'netguru/BlueSwift' ~> 1.1.3`
+, or including version - `github 'netguru/BlueSwift' ~> 1.1.4`
 
 ## 📄 License
 


### PR DESCRIPTION
### Title
Refactor removing peripheral from list to not use array index.

### Motivation
Index based removal of array element can sometimes cause index-out-of-bonds error in concurrent environment.
