### PR TITLE
Synchronize access to peripherals array

### DIFF
--- a/Bluetooth.xcodeproj/project.pbxproj
+++ b/Bluetooth.xcodeproj/project.pbxproj
@@ -45,6 +45,9 @@
 		4B2ACCCF29083F5400EF10B6 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 4B2ACCCE29083F5400EF10B6 /* CHANGELOG.md */; };
 		4B62466A280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B624669280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift */; };
 		4B9FB9F1296DECF900C778A4 /* SynchronizedArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B9FB9EF296DEC9D00C778A4 /* SynchronizedArray.swift */; };
+		4BDD6CDE2978626300918E27 /* SynchronizedArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDD6CDD2978626300918E27 /* SynchronizedArrayTests.swift */; };
+		4BDD6CE02979410D00918E27 /* DispatchQueueProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDD6CDF2979410D00918E27 /* DispatchQueueProtocol.swift */; };
+		4BDD6CE429794ADC00918E27 /* MockDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDD6CE229794AD800918E27 /* MockDispatchQueue.swift */; };
 		4BEB6E6F2800735D0061C702 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEB6E6E2800735D0061C702 /* Sequence.swift */; };
 		4BEB6E72280077010061C702 /* SequenceExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */; };
 /* End PBXBuildFile section */
@@ -160,6 +163,9 @@
 		4B2ACCCE29083F5400EF10B6 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		4B624669280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothAuthorizationStatus.swift; sourceTree = "<group>"; };
 		4B9FB9EF296DEC9D00C778A4 /* SynchronizedArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedArray.swift; sourceTree = "<group>"; };
+		4BDD6CDD2978626300918E27 /* SynchronizedArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedArrayTests.swift; sourceTree = "<group>"; };
+		4BDD6CDF2979410D00918E27 /* DispatchQueueProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueProtocol.swift; sourceTree = "<group>"; };
+		4BDD6CE229794AD800918E27 /* MockDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDispatchQueue.swift; sourceTree = "<group>"; };
 		4BEB6E6E2800735D0061C702 /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
 		4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceExtensionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -319,10 +325,12 @@
 		38FE6BA62006898100809A06 /* Unit Tests */ = {
 			isa = PBXGroup;
 			children = (
+				4BDD6CE129794AC900918E27 /* Mocks */,
 				38FE6BA72006898100809A06 /* ExtensionTests.swift */,
 				4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */,
 				382CD41E2028F4B50065DFF6 /* CommandTests.swift */,
 				38FE6BA82006898100809A06 /* ConfigurationTests.swift */,
+				4BDD6CDD2978626300918E27 /* SynchronizedArrayTests.swift */,
 				38FE6BA92006898100809A06 /* Info.plist */,
 			);
 			path = "Unit Tests";
@@ -485,8 +493,17 @@
 			isa = PBXGroup;
 			children = (
 				4B9FB9EF296DEC9D00C778A4 /* SynchronizedArray.swift */,
+				4BDD6CDF2979410D00918E27 /* DispatchQueueProtocol.swift */,
 			);
 			path = Utilities;
+			sourceTree = "<group>";
+		};
+		4BDD6CE129794AC900918E27 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				4BDD6CE229794AD800918E27 /* MockDispatchQueue.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -659,6 +676,7 @@
 				3863BE67200BD5E700FD4EC9 /* Command.swift in Sources */,
 				38FE6BD92006898100809A06 /* Peripheral.swift in Sources */,
 				38FE6BDB2006898100809A06 /* Characteristic.swift in Sources */,
+				4BDD6CE02979410D00918E27 /* DispatchQueueProtocol.swift in Sources */,
 				38BE35DF203DD6B30018EA0D /* AdvertisablePeripheral.swift in Sources */,
 				382CD41D2028F1360065DFF6 /* Data.swift in Sources */,
 				38FE6BD52006898100809A06 /* ConnectionService.swift in Sources */,
@@ -676,10 +694,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4BDD6CDE2978626300918E27 /* SynchronizedArrayTests.swift in Sources */,
 				4BEB6E72280077010061C702 /* SequenceExtensionTests.swift in Sources */,
 				382CD41F2028F4B50065DFF6 /* CommandTests.swift in Sources */,
 				38FE6BE7200689AB00809A06 /* ConfigurationTests.swift in Sources */,
 				38FE6BE6200689A700809A06 /* ExtensionTests.swift in Sources */,
+				4BDD6CE429794ADC00918E27 /* MockDispatchQueue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bluetooth.xcodeproj/project.pbxproj
+++ b/Bluetooth.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		4B2ACCCD29083F4300EF10B6 /* Readme.md in Resources */ = {isa = PBXBuildFile; fileRef = 4B2ACCCC29083F4200EF10B6 /* Readme.md */; };
 		4B2ACCCF29083F5400EF10B6 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 4B2ACCCE29083F5400EF10B6 /* CHANGELOG.md */; };
 		4B62466A280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B624669280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift */; };
+		4B9FB9F1296DECF900C778A4 /* SynchronizedArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B9FB9EF296DEC9D00C778A4 /* SynchronizedArray.swift */; };
 		4BEB6E6F2800735D0061C702 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEB6E6E2800735D0061C702 /* Sequence.swift */; };
 		4BEB6E72280077010061C702 /* SequenceExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */; };
 /* End PBXBuildFile section */
@@ -158,6 +159,7 @@
 		4B2ACCCC29083F4200EF10B6 /* Readme.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Readme.md; sourceTree = "<group>"; };
 		4B2ACCCE29083F5400EF10B6 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		4B624669280811CA009A8CC7 /* BluetoothAuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothAuthorizationStatus.swift; sourceTree = "<group>"; };
+		4B9FB9EF296DEC9D00C778A4 /* SynchronizedArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedArray.swift; sourceTree = "<group>"; };
 		4BEB6E6E2800735D0061C702 /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
 		4BEB6E70280075510061C702 /* SequenceExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceExtensionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -376,6 +378,7 @@
 		38FE6BB62006898100809A06 /* Source Files */ = {
 			isa = PBXGroup;
 			children = (
+				4B9FB9EE296DEC8A00C778A4 /* Utilities */,
 				38974AF5203732B50024CCD5 /* Advertisement */,
 				38FE6BB72006898100809A06 /* Connection */,
 				38FE6BBA2006898100809A06 /* Extensions */,
@@ -476,6 +479,14 @@
 				3A369633210F1C4E007C62F1 /* CoreBluetooth.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4B9FB9EE296DEC8A00C778A4 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				4B9FB9EF296DEC9D00C778A4 /* SynchronizedArray.swift */,
+			);
+			path = Utilities;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -653,6 +664,7 @@
 				38FE6BD52006898100809A06 /* ConnectionService.swift in Sources */,
 				38974AFA20373A660024CCD5 /* AdvertisementService.swift in Sources */,
 				38974AF8203738F30024CCD5 /* BluetoothAdvertisement.swift in Sources */,
+				4B9FB9F1296DECF900C778A4 /* SynchronizedArray.swift in Sources */,
 				38FE6BDC2006898100809A06 /* Configuration.swift in Sources */,
 				382516562049899F0097F9D7 /* AdvertisementData.swift in Sources */,
 				38FE6BD62006898100809A06 /* BluetoothConnection.swift in Sources */,

--- a/Bluetooth.xcodeproj/xcshareddata/xcschemes/BlueSwift-iOS.xcscheme
+++ b/Bluetooth.xcodeproj/xcshareddata/xcschemes/BlueSwift-iOS.xcscheme
@@ -54,7 +54,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3837BA301FFFC4CE00DF300E"
+            BuildableName = "BlueSwift.framework"
+            BlueprintName = "Bluetooth"
+            ReferencedContainer = "container:Bluetooth.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -67,17 +77,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "3837BA301FFFC4CE00DF300E"
-            BuildableName = "BlueSwift.framework"
-            BlueprintName = "Bluetooth"
-            ReferencedContainer = "container:Bluetooth.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -98,8 +97,6 @@
             ReferencedContainer = "container:Bluetooth.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"

--- a/Framework/Source Files/Utilities/DispatchQueueProtocol.swift
+++ b/Framework/Source Files/Utilities/DispatchQueueProtocol.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright © 2023 Netguru Sp. z o.o. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+/// Protocol describing a `DispatchQueue`.
+protocol DispatchQueueProtocol: AnyObject {
+
+    /// Submits a work item for execution and returns the results from that item after it finishes executing.
+    /// - Parameter work: The block that contains the work to perform.
+    /// - Returns: The return value of the item in the work parameter.
+    func sync<T>(execute work: () throws -> T) rethrows -> T
+
+    /// Schedules a block asynchronously for execution
+    /// - Parameters:
+    ///   - flags: Additional attributes to apply when executing the block. For a list of possible values, see `DispatchWorkItemFlags`.
+    ///   - work: The block containing the work to perform. This block has no return value and no parameters.
+    func async(flags: DispatchWorkItemFlags, execute work: @escaping @convention(block) () -> Void)
+}
+
+extension DispatchQueue: DispatchQueueProtocol {
+
+    /// Convenience version of `DispatchQueue/async(group:qos:flags:execute:)` method.
+    /// SeeAlso: ``DispatchQueueProtocol/async(flags:execute:)``
+    func async(flags: DispatchWorkItemFlags = [], execute work: @escaping @convention(block) () -> Void) {
+        async(group: nil, qos: .unspecified, flags: flags, execute: work)
+    }
+}

--- a/Framework/Source Files/Utilities/SynchronizedArray.swift
+++ b/Framework/Source Files/Utilities/SynchronizedArray.swift
@@ -1,0 +1,123 @@
+//
+//  Copyright © 2023 Netguru Sp. z o.o. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+/// A thread-safe `Array`, which synchronizes access to its elements.
+/// To avoid race condition while performing multiple operations on ``SynchronizedArray`` use ``SynchronizedArray/read(_:)`` and ``SynchronizedArray/write(_:)`` methods.
+final class SynchronizedArray<Element> {
+
+    /// A concurrent queue which manages access to ``SynchronizedArray/storage``.
+    private let queue = DispatchQueue(label: "com.keto-mojo.sdk.framework.SynchronizedArray", attributes: .concurrent)
+    /// Internal storage of the ``SynchronizedArray``.
+    private var storage: [Element]
+
+    /// Initializes new ``SynchronizedArray`` with empty storage.
+    init() {
+        storage = []
+    }
+
+    /// Initializes new ``SynchronizedArray`` with containing provided elements.
+    convenience init(contentsOf array: [Element]) {
+        self.init()
+        storage = array
+    }
+
+    /// Allows accessing element by its index.
+    subscript(_ index: Int) -> Element {
+        get {
+            read {
+                $0[index]
+            }
+        }
+        set {
+            write {
+                $0[index] = newValue
+            }
+        }
+    }
+}
+
+extension SynchronizedArray {
+
+    /// The number of elements in the array.
+    var count: Int {
+        read { $0.count }
+    }
+
+    /// The first element of the array.
+    var first: Element? {
+        read { $0.first }
+    }
+
+    /// Adds a new element at the end of the array.
+    /// - Parameter newElement: The element to append to the array.
+    func append(_ newElement: Element) {
+        write {
+            $0.append(newElement)
+        }
+    }
+
+    /// Removes and returns the element at the specified position.
+    /// - Parameter index: The position of the element to remove. index must be a valid index of the array.
+    func remove(at index: Int) {
+        write {
+            $0.remove(at: index)
+        }
+    }
+
+    /// Removes all the elements that satisfy the given predicate.
+    /// - Parameter shouldBeRemoved: A closure that takes an element of the sequence as its argument and returns a Boolean value indicating whether the element should be removed from the array.
+    func removeAll(where shouldBeRemoved: @escaping (Element) -> Bool) {
+        write {
+            $0.removeAll(where: shouldBeRemoved)
+        }
+    }
+
+    /// Removes the element at the specified position, checking if provided position is a valid index of the array.
+    /// - Parameter index: The position of the element to remove.
+    func safelyRemove(at index: Int) {
+        write {
+            guard index < $0.count, index >= 0 else { return }
+            $0.remove(at: index)
+        }
+    }
+
+    /// Returns the first element of the sequence that satisfies the given predicate.
+    /// - Parameter predicate: A closure that takes an element of the sequence as its argument and returns a Boolean value indicating whether the element is a match.
+    /// - Returns: an element from the array.
+    func first(where predicate: (Element) -> Bool) -> Element? {
+        read {
+            $0.first(where: predicate)
+        }
+    }
+}
+
+extension SynchronizedArray {
+
+    /// Use `read` method to execute multiple read-operations on the data.
+    /// - Parameter block: block of code which takes the storage (`[Element]`) as argument and returns a value.
+    /// - Returns: result of block of code.
+    func read<T>(_ block: ([Element]) throws -> T) rethrows -> T {
+        try queue.sync {
+            try block(storage)
+        }
+    }
+    /// Use `write` method to execute multiple write-operations on the data.
+    /// - Parameter block: block of code which takes the storage (`[Element]`) as argument and allows to mutate it.
+    func write(_ block: @escaping (inout [Element]) -> Void) {
+        queue.async(flags: .barrier) {
+            block(&self.storage)
+        }
+    }
+}
+
+extension SynchronizedArray: ExpressibleByArrayLiteral {
+
+    /// SeeAlso: ``ExpressibleByArrayLiteral/init(arrayLiteral:)``.
+    convenience init(arrayLiteral elements: Element...) {
+        self.init(contentsOf: elements)
+    }
+}

--- a/Framework/Source Files/Utilities/SynchronizedArray.swift
+++ b/Framework/Source Files/Utilities/SynchronizedArray.swift
@@ -10,7 +10,7 @@ import Foundation
 final class SynchronizedArray<Element> {
 
     /// A concurrent queue which manages access to ``SynchronizedArray/storage``.
-    private let queue = DispatchQueue(label: "com.keto-mojo.sdk.framework.SynchronizedArray", attributes: .concurrent)
+    private let queue = DispatchQueue(label: "co.netguru.lib.blueswift.SynchronizedArray", attributes: .concurrent)
     /// Internal storage of the ``SynchronizedArray``.
     private var storage: [Element]
 

--- a/Unit Tests/Mocks/MockDispatchQueue.swift
+++ b/Unit Tests/Mocks/MockDispatchQueue.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright © 2018 Netguru Sp. z o.o. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+@testable import BlueSwift
+
+class MockDispatchQueue: DispatchQueueProtocol {
+
+    func sync<T>(execute work: () throws -> T) rethrows -> T {
+        try work()
+    }
+
+    func async(flags: DispatchWorkItemFlags, execute work: @escaping @convention(block) () -> Void) {
+        work()
+    }
+}

--- a/Unit Tests/SynchronizedArrayTests.swift
+++ b/Unit Tests/SynchronizedArrayTests.swift
@@ -1,0 +1,205 @@
+//
+//  Copyright © 2018 Netguru Sp. z o.o. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+import CoreBluetooth.CBUUID
+@testable import BlueSwift
+
+class SynchronizedArrayTests: XCTestCase {
+
+    func testInitializers() {
+        // given
+        var sut = SynchronizedArray<Int>()
+
+        // then
+        XCTAssertTrue(sut.isEmpty)
+        XCTAssertEqual(sut.count, 0)
+
+        // given
+        sut = .init(arrayLiteral: 1, 2, 3)
+
+        // then
+        XCTAssertEqual(sut.count, 3)
+        XCTAssertEqual(sut[0], 1)
+        XCTAssertEqual(sut[1], 2)
+        XCTAssertEqual(sut[2], 3)
+
+        // given
+        sut = .init(contentsOf: [3, 4])
+
+        // then
+        XCTAssertEqual(sut.count, 2)
+        XCTAssertEqual(sut[0], 3)
+        XCTAssertEqual(sut[1], 4)
+    }
+
+    func testSubscript() {
+        // given
+        let queue = MockDispatchQueue()
+        let sut: SynchronizedArray<Int> = .init(queue: queue)
+        sut.append(contentsOf: [1, 2, 3])
+
+        // then
+        XCTAssertEqual(sut[0], 1)
+        XCTAssertEqual(sut[1], 2)
+        XCTAssertEqual(sut[2], 3)
+
+        // when
+        sut[0] = 4
+        sut[1] = 5
+        sut[2] = 6
+
+        // then
+        XCTAssertEqual(sut, [4, 5, 6])
+    }
+
+    func testFirstAndLast() {
+        // given
+        var sut: SynchronizedArray<Int> = []
+
+        // then
+        XCTAssertNil(sut.first)
+        XCTAssertNil(sut.last)
+
+        // given
+        sut = [2]
+
+        // then
+        XCTAssertEqual(sut.first, 2)
+        XCTAssertEqual(sut.last, 2)
+
+        // given
+        sut = [1, 2, 3]
+
+        // then
+        XCTAssertEqual(sut.first, 1)
+        XCTAssertEqual(sut.last, 3)
+
+        // when
+        let element = sut.first(where: { $0 == 2 })
+
+        // then
+        XCTAssertEqual(element, 2)
+    }
+
+    func testEquality() {
+        // given
+        var sut1: SynchronizedArray<String> = []
+        var sut2: SynchronizedArray<String> = []
+
+        // then
+        XCTAssertEqual(sut1, sut2)
+
+        // given
+        sut1 = ["string"]
+        sut2 = []
+
+        // then
+        XCTAssertNotEqual(sut1, sut2)
+
+        // given
+        sut1 = ["fixture", "string"]
+        sut2 = ["fixture", "string"]
+
+        // then
+        XCTAssertEqual(sut1, sut2)
+    }
+
+    func testAppend() {
+        // given
+        let queue = MockDispatchQueue()
+        let sut: SynchronizedArray<Int> = .init(queue: queue)
+
+        // when
+        sut.append(1)
+
+        // then
+        XCTAssert(sut == [1])
+
+        // when
+        sut.append(2)
+
+        // then
+        XCTAssertEqual(sut, [1, 2])
+
+        // when
+        sut.append(contentsOf: [3, 4, 5])
+
+        // then
+        XCTAssertEqual(sut, [1, 2, 3, 4, 5])
+    }
+
+    func testRemove() {
+        // given
+        let queue = MockDispatchQueue()
+        let sut: SynchronizedArray<Int> = .init(queue: queue)
+
+        // when
+        sut.removeAll(where: { _ in true })
+
+        // then
+        XCTAssert(sut.isEmpty)
+
+        // given
+        sut.append(contentsOf: [1, 2, 3])
+
+        // when
+        sut.removeAll(where: { _ in false })
+
+        // then
+        XCTAssertEqual(sut, [1, 2, 3])
+
+        // when
+        sut.removeAll(where: { $0 == 2 })
+
+        // then
+        XCTAssertEqual(sut, [1, 3])
+
+        // when
+        sut.removeAll(where: { _ in true })
+
+        // then
+        XCTAssertEqual(sut, [])
+
+        // given
+        sut.append(contentsOf: [1, 2, 3, 4, 5])
+
+        // when
+        sut.safelyRemove(at: 5)
+
+        // then
+        XCTAssertEqual(sut, [1, 2, 3, 4, 5])
+
+        // when
+        sut.safelyRemove(at: 4)
+
+        // then
+        XCTAssertEqual(sut, [1, 2, 3, 4])
+
+        // when
+        sut.remove(at: 3)
+
+        // then
+        XCTAssertEqual(sut, [1, 2, 3])
+
+        // when
+        sut.remove(at: 0)
+
+        // then
+        XCTAssertEqual(sut, [2, 3])
+    }
+
+    func testConcurrentAppend() {
+        let sut = SynchronizedArray<Int>()
+        let iterations = 1000
+
+        // Regular Swift `Array` would crash here (`EXC_BAD_ACCESS`):
+        DispatchQueue.concurrentPerform(iterations: iterations) { index in
+            sut.append(index)
+        }
+
+        XCTAssertEqual(sut.count, iterations)
+    }
+}


### PR DESCRIPTION
### Title
Synchronize access peripherals array

### Motivation
Synchronize access to an array of peripherals to prevent a race condition when using `BlueSwift` methods concurrently.
For example, BlueSwift could crash when `BluetoothConnection/disconnect(_:)` is called in a loop. Framework never declared such operation to be unsafe, hence the change, aiming to make it safe.

### Task Description
- implement `SynchronizedArray` data structure
- use `SynchronizedArray ` to internally store peripherals
- a block of read/write operations is called using `SynchronizedArray/read(_:)` and `SynchronizedArray/write(_:)`