### PR TITLE
Update the required version of iOS in podpsec

### DIFF
--- a/BlueSwift.podspec
+++ b/BlueSwift.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |spec|
   spec.frameworks = 'Foundation', 'CoreBluetooth'
 
   spec.swift_version = '5.3'
-  spec.ios.deployment_target = '11.0'
+  spec.ios.deployment_target = '13.1'
 
 end


### PR DESCRIPTION
### Title
Update the required version of iOS in podpsec

### Motivation
previous version was wrongly configured as some of the api's used in the project require iOs 13.1