### PR TITLE
Fix official cocopods release

### DIFF
--- a/BlueSwift.podspec
+++ b/BlueSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name = 'BlueSwift'
-  spec.version = '1.1.4'
+  spec.version = '1.1.5'
   spec.summary = 'Easy and lightweight CoreBluetooth wrapper written in Swift'
   spec.homepage = 'https://github.com/netguru/BlueSwift'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.1.5] - 2023-01-24
+
+### Changed
+
+- Fix official cocoapods release
+
 ## [1.1.4] - 2023-01-20
 
 ### Changed

--- a/Configurations/Common/Common-Base.xcconfig
+++ b/Configurations/Common/Common-Base.xcconfig
@@ -5,7 +5,7 @@
 
 #include "../xcconfigs/Common/Common.xcconfig"
 
-_BUILD_VERSION = 1.1.4
+_BUILD_VERSION = 1.1.5
 _BUILD_NUMBER = 1
 
 _DEPLOYMENT_TARGET_IOS = 11.0

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -40,9 +40,9 @@ internal final class ConnectionService: NSObject {
 
     /// Current Bluetooth authorization status.
     internal var bluetoothAuthorizationStatus: BluetoothAuthorizationStatus {
-        if #available(iOSApplicationExtension 13.1, *) {
+        if #available(iOS 13.1, *) {
             return CBManager.authorization.bluetoothAuthorizationStatus
-        } else if #available(iOSApplicationExtension 13.0, *) {
+        } else if #available(iOS 13.0, *) {
             return centralManager.authorization.bluetoothAuthorizationStatus
         } else {
             // Until iOS 12 applications could access Bluetooth without the user’s authorization

--- a/Framework/Source Files/Model/BluetoothAuthorizationStatus.swift
+++ b/Framework/Source Files/Model/BluetoothAuthorizationStatus.swift
@@ -20,10 +20,10 @@ import CoreBluetooth
     case allowedAlways = 3
 }
 
-@available(iOSApplicationExtension 13.0, *)
 extension BluetoothAuthorizationStatus {
 
     /// `CBManagerAuthorization` representation of current authorization status.
+    @available(iOS 13.0, *)
     var cbManagerAuthorization: CBManagerAuthorization {
         switch self {
         case .notDetermined:
@@ -38,10 +38,11 @@ extension BluetoothAuthorizationStatus {
     }
 }
 
-@available(iOSApplicationExtension 13.0, *)
+@available(iOS 13.0, *)
 extension CBManagerAuthorization {
 
     /// `BluetoothAuthorizationStatus` representation of current authorization status.
+    @available(iOSApplicationExtension 13.0, *)
     var bluetoothAuthorizationStatus: BluetoothAuthorizationStatus {
         switch self {
         case .notDetermined:

--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ Just drop the line below to your Podfile:
 
 `pod 'BlueSwift'`
 
-(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.1.4'`)
+(but probably you'd like to pin it to the nearest major release, so `pod 'BlueSwift' , '~> 1.1.5'`)
 
 ### ![](https://img.shields.io/badge/carthage-compatible-green.svg)
 
@@ -103,7 +103,7 @@ The same as with Cocoapods, insert the line below to your Cartfile:
 
 `github 'netguru/BlueSwift'`
 
-, or including version - `github 'netguru/BlueSwift' ~> 1.1.4`
+, or including version - `github 'netguru/BlueSwift' ~> 1.1.5`
 
 ## 📄 License
 


### PR DESCRIPTION
### Title
Fix official cocopods release

### Motivation
BlueSwift was not released to official cocoapods repo for a long time, the version 1.1.4 had wrongly configured min target. 1.1.5 should fix all the issues.
Due to unknown reason when using `#available(iOSApplicationExtension 13.0, *)` cocoapods build was not passing properly. Changing it to the version from this PR fixed the problem.

### Task Description
<!-- What should and what actually happens. -->
