### PR TITLE
Fix Swift 5.9 error when converting integer to data

### DIFF
--- a/Framework/Source Files/Extensions/Int.swift
+++ b/Framework/Source Files/Extensions/Int.swift
@@ -7,10 +7,10 @@ import Foundation
 
 /// Extension for signed integers allowing conversion to Data with proper size.
 internal extension UnsignedInteger {
-    
+
     /// Returns decoded data with proper size.
     var decodedData: Data {
-        var mutableSelf = self
-        return Data(bytes: &mutableSelf, count: MemoryLayout<Self>.size)
+        let data = withUnsafeBytes(of: self) { Data($0) }
+        return data
     }
 }

--- a/Framework/Source Files/Extensions/Int.swift
+++ b/Framework/Source Files/Extensions/Int.swift
@@ -10,7 +10,6 @@ internal extension UnsignedInteger {
 
     /// Returns decoded data with proper size.
     var decodedData: Data {
-        let data = withUnsafeBytes(of: self) { Data($0) }
-        return data
+        return withUnsafeBytes(of: self) { Data($0) }
     }
 }


### PR DESCRIPTION
### Title
BlueSwift fails to build using Swift 5.9 (Xcode 15), because `Data(bytes:count:)` throws error `Forming 'UnsafeRawPointer' to a variable of type 'Self'; this is likely incorrect because 'Self' may contain an object reference.`
Using `withUnsafeBytes(of:_)` resolves the issue.