### PR TITLE
Support macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ DerivedData
 
 Pods
 Carthage
+.swiftpm

--- a/Framework/Source Files/Advertisement/AdvertisementService.swift
+++ b/Framework/Source Files/Advertisement/AdvertisementService.swift
@@ -30,10 +30,10 @@ internal final class AdvertisementService: NSObject {
     internal var writeCallback: ((Characteristic, Data?) -> ())?
     
     /// Callback called upon upcoming errors.
-    private var errorHandler: ((AdvertisementError) -> ())?
+    private var errorHandler: ((AdvertisementError?) -> ())?
     
     /// Starts advertising peripheral with given configuration of services and characteristics.
-    internal func startAdvertising(_ peripheral: Peripheral<Advertisable>, errorHandler: ((AdvertisementError) -> ())?) {
+    internal func startAdvertising(_ peripheral: Peripheral<Advertisable>, errorHandler: ((AdvertisementError?) -> ())?) {
         self.peripheral = peripheral
         self.errorHandler = errorHandler
         peripheralManager.startAdvertising(peripheral.advertisementData?.combined())
@@ -81,6 +81,7 @@ extension AdvertisementService: CBPeripheralManagerDelegate {
             return
         }
         self.peripheral?.configuration.services.map({ $0.assignAdvertisementService() }).forEach(peripheralManager.add(_:))
+        errorHandler?(nil)
     }
     
     /// - SeeAlso: `CBPeripheralManagerDelegate`

--- a/Framework/Source Files/Advertisement/BluetoothAdvertisement.swift
+++ b/Framework/Source Files/Advertisement/BluetoothAdvertisement.swift
@@ -25,7 +25,7 @@ public final class BluetoothAdvertisement {
     ///     - errorHandler: an error handler. Will be called only after unsuccessfull advertisement setup.
     /// - SeeAlso: `AdvertisementError`
     /// - SeeAlso: `Peripheral`
-    public func advertise(peripheral: Peripheral<Advertisable>, errorHandler: ((AdvertisementError) -> ())?) {
+    public func advertise(peripheral: Peripheral<Advertisable>, errorHandler: ((AdvertisementError?) -> ())?) {
         advertisementService.startAdvertising(peripheral, errorHandler: errorHandler)
     }
     

--- a/Framework/Source Files/Connection/ConnectionService.swift
+++ b/Framework/Source Files/Connection/ConnectionService.swift
@@ -84,18 +84,9 @@ extension ConnectionService {
     
     /// Starts connection with passed device. Connection result is passed in handler closure.
     internal func connect(_ peripheral: Peripheral<Connectable>, handler: @escaping (Peripheral<Connectable>, ConnectionError?) -> ()) {
-        if connectionHandler == nil {
-            connectionHandler = handler
-        }
-        do {
-            try centralManager.validateState()
-            peripherals.append(peripheral)
-            reloadScanning()
-        } catch let error {
-            if let error = error as? BluetoothError {
-                handler(peripheral, .bluetoothError(error))
-            }
-        }
+        connectionHandler = handler
+        peripherals.append(peripheral)
+        reloadScanning()
     }
     
     /// Disconnects given device.

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 
  let package = Package(
      name: "BlueSwift",
-     platforms: [ .iOS(.v10) ],
+     platforms: [ .iOS(.v10), .macOS(.v11) ],
      products: [
          .library(
              name: "BlueSwift",


### PR DESCRIPTION
### Title
Support macOS

### Motivation
It'll be good to support macOS because macOS supports Bluetooth.
It'll also help with testing.

### Task Description
There are two changes:
1. Refactoring `ConnectionSerivce.connect()`:
`centralManager.validateState()` failed when tested on macOS.
I don't think testing the state as soon as we create the `CBCentralManager` makes sense.
We should test the state in `centralManagerDidUpdateState()` and we are doing it there already.
2. Make `AdvertisementError` optional:
I made it optional to call the error handler even on success.
We are doing the same in `ConnectionSerivce.connect()` and it tells the app whether the advertisement succeeds.

Also, updated `Package.swift` to support macOS.
